### PR TITLE
Restructure dashboard layout for dual-column experience

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,9 +14,9 @@
       --ui-scale: 1;
       --bg: #04060e;
       --bg-accent: #080b17;
-      --panel: rgba(14, 18, 32, 0.9);
-      --panel-border: rgba(92, 104, 152, 0.28);
-      --panel-highlight: rgba(124, 92, 255, 0.42);
+      --panel: rgba(10, 13, 22, 0.88);
+      --panel-border: rgba(76, 92, 142, 0.35);
+      --panel-highlight: rgba(124, 92, 255, 0.28);
       --muted: rgba(22, 26, 40, 0.92);
       --text: #f5f7ff;
       --subtle: #9da6c4;
@@ -30,14 +30,14 @@
       --success: #3ddc97;
       --danger: #ff6b6b;
       --danger-soft: rgba(255, 107, 107, 0.18);
-      --radius: 18px;
-      --shadow: 0 22px 55px rgba(5, 8, 22, 0.55);
-      --shadow-soft: 0 16px 38px rgba(5, 8, 22, 0.45);
-      --pill-bg: rgba(34, 40, 60, 0.85);
-      --input-bg: rgba(14, 18, 28, 0.88);
-      --input-border: rgba(102, 119, 163, 0.28);
-      --chip-bg: rgba(54, 62, 92, 0.55);
-      --chip-border: rgba(116, 132, 188, 0.35);
+      --radius: 16px;
+      --shadow: 0 18px 40px rgba(5, 8, 22, 0.48);
+      --shadow-soft: 0 12px 28px rgba(5, 8, 22, 0.38);
+      --pill-bg: rgba(34, 40, 60, 0.78);
+      --input-bg: rgba(14, 18, 28, 0.9);
+      --input-border: rgba(102, 119, 163, 0.26);
+      --chip-bg: rgba(54, 62, 92, 0.52);
+      --chip-border: rgba(116, 132, 188, 0.32);
       --toast-bg: rgba(18, 22, 34, 0.94);
       --popup-scale: 1;
     }
@@ -50,17 +50,56 @@
       margin: 0;
       font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
       background:
-        radial-gradient(1400px 900px at -10% -20%, rgba(132, 96, 255, 0.22), transparent),
-        radial-gradient(1200px 700px at 120% 0%, rgba(47, 103, 255, 0.18), transparent),
-        linear-gradient(160deg, var(--bg) 0%, var(--bg-accent) 55%, #02030a 100%);
+        radial-gradient(1200px 760px at -10% -20%, rgba(132, 96, 255, 0.16), transparent 70%),
+        radial-gradient(980px 620px at 120% -10%, rgba(47, 103, 255, 0.14), transparent 65%),
+        linear-gradient(160deg, #050711 0%, #080d19 55%, #02030a 100%);
       color: var(--text);
       -webkit-font-smoothing: antialiased;
-      padding: 48px 20px 64px;
+      padding: 44px 24px 64px;
     }
 
     body.is-modal-open { overflow: hidden; }
 
-    .app { max-width: 1080px; margin: 0 auto; display: flex; flex-direction: column; gap: 24px; }
+    .app { max-width: 1320px; margin: 0 auto; display: flex; flex-direction: column; gap: 28px; }
+
+    .layout-grid {
+      display: grid;
+      gap: 28px;
+    }
+
+    .layout-col {
+      display: flex;
+      flex-direction: column;
+      gap: 28px;
+    }
+
+    .layout-col--secondary {
+      gap: 26px;
+      align-self: start;
+    }
+
+    @media (min-width: 1100px) {
+      .layout-grid {
+        grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+        align-items: start;
+      }
+      .layout-col--secondary {
+        position: sticky;
+        top: 48px;
+      }
+    }
+
+    @media (max-width: 1099px) {
+      .layout-col--secondary {
+        position: static;
+      }
+    }
+
+    @media (max-width: 720px) {
+      .app { gap: 24px; }
+      .layout-grid { gap: 24px; }
+      .layout-col { gap: 24px; }
+    }
 
     .panel {
       position: relative;
@@ -69,15 +108,15 @@
       flex-direction: column;
       gap: 20px;
       border-radius: var(--radius);
-      padding: 28px 32px;
+      padding: 26px 28px;
       --panel-bg: var(--panel);
       --panel-border-color: var(--panel-border);
-      --panel-glow: rgba(124, 92, 255, 0.16);
-      --panel-sheen: rgba(255, 255, 255, 0.06);
+      --panel-glow: rgba(124, 92, 255, 0.1);
+      --panel-sheen: rgba(255, 255, 255, 0.04);
       border: 1px solid var(--panel-border-color);
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 32%) var(--panel-bg);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 32%) var(--panel-bg);
       box-shadow: var(--shadow);
-      backdrop-filter: blur(22px) saturate(1.05);
+      backdrop-filter: blur(18px) saturate(1.05);
     }
 
     .panel::before,
@@ -86,36 +125,36 @@
     .panel::before {
       inset: -40% -35%;
       background: radial-gradient(ellipse at top left, var(--panel-glow), transparent 60%);
-      opacity: 0.85;
-      transform: rotate(8deg);
+      opacity: 0.55;
+      transform: rotate(6deg);
     }
 
     .panel::after {
-      background: linear-gradient(135deg, var(--panel-sheen), transparent 65%);
+      background: linear-gradient(135deg, var(--panel-sheen), transparent 70%);
       mix-blend-mode: screen;
     }
 
     .panel > * { position: relative; z-index: 1; }
 
     .panel--accent {
-      --panel-bg: rgba(18, 22, 42, 0.92);
-      --panel-border-color: color-mix(in srgb, var(--accent) 40%, rgba(118, 134, 189, 0.4));
-      --panel-glow: color-mix(in srgb, var(--accent) 28%, rgba(124, 92, 255, 0.26));
-      --panel-sheen: rgba(255, 255, 255, 0.08);
-      box-shadow: 0 28px 70px rgba(8, 12, 30, 0.55);
+      --panel-bg: rgba(16, 20, 36, 0.9);
+      --panel-border-color: color-mix(in srgb, var(--accent) 36%, rgba(118, 134, 189, 0.45));
+      --panel-glow: color-mix(in srgb, var(--accent) 24%, rgba(124, 92, 255, 0.22));
+      --panel-sheen: rgba(255, 255, 255, 0.06);
+      box-shadow: 0 24px 60px rgba(8, 12, 30, 0.5);
     }
 
     .panel--neutral {
-      --panel-bg: rgba(16, 20, 32, 0.88);
-      --panel-border-color: rgba(118, 134, 189, 0.28);
-      --panel-glow: rgba(118, 134, 189, 0.18);
-      --panel-sheen: rgba(255, 255, 255, 0.05);
+      --panel-bg: rgba(13, 16, 26, 0.9);
+      --panel-border-color: rgba(118, 134, 189, 0.26);
+      --panel-glow: rgba(118, 134, 189, 0.14);
+      --panel-sheen: rgba(255, 255, 255, 0.04);
     }
 
     .panel--muted {
-      --panel-bg: rgba(12, 16, 26, 0.85);
-      --panel-border-color: rgba(92, 104, 152, 0.2);
-      --panel-glow: rgba(84, 96, 138, 0.16);
+      --panel-bg: rgba(11, 14, 22, 0.88);
+      --panel-border-color: rgba(92, 104, 152, 0.22);
+      --panel-glow: rgba(84, 96, 138, 0.12);
       --panel-sheen: rgba(255, 255, 255, 0.03);
       box-shadow: var(--shadow-soft);
     }
@@ -173,12 +212,6 @@
     .status-dot.active { background: var(--success); box-shadow: 0 0 0 4px rgba(61, 220, 151, 0.22); }
     .status-value { color: var(--text); font-weight: 600; }
     .status-value.is-full { color: var(--danger); }
-
-    .grid-two {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-      gap: 24px;
-    }
 
     .section-title { font-size: 18px; font-weight: 600; letter-spacing: 0.2px; }
     .section-sub { font-size: 13px; color: rgba(201, 208, 230, 0.75); }
@@ -1129,280 +1162,284 @@
       </div>
     </div>
 
-    <div class="grid-two">
-      <section class="panel panel--neutral" id="tickerPanel">
-        <div>
-          <div class="section-title">Ticker Timing</div>
-          <div class="section-sub">Control rotation and cooldown cadence. Intervals are stored in minutes (0–60) and converted server-side.</div>
-        </div>
-        <div class="control-grid">
-          <div class="control-group">
-            <label for="displayDuration">Display Duration (seconds)</label>
-            <input type="number" id="displayDuration" min="2" max="90" step="1" value="5" />
+    <div class="layout-grid">
+      <div class="layout-col layout-col--primary">
+        <section class="panel panel--neutral" id="tickerPanel">
+          <div>
+            <div class="section-title">Ticker Timing</div>
+            <div class="section-sub">Control rotation and cooldown cadence. Intervals are stored in minutes (0–60) and converted server-side.</div>
           </div>
-          <div class="control-group">
-            <label for="intervalMinutes">Interval Between Messages (minutes)</label>
-            <input type="number" id="intervalMinutes" min="0" max="60" step="0.01" value="0" />
-          </div>
-        </div>
-        <div class="actions">
-          <button class="btn btn-success" id="startBtn">Start</button>
-          <button class="btn btn-danger" id="stopBtn">Stop</button>
-          <div class="spacer"></div>
-          <button class="btn btn-secondary" id="refreshBtn">Refresh</button>
-        </div>
-      </section>
-
-      <section class="panel panel--accent" id="overlayPanel">
-        <div>
-          <div class="section-title">Overlay Styling</div>
-          <div class="section-sub">Adjust label, highlights, animation preferences, and scale for the browser source preview.</div>
-        </div>
-        <div class="control-grid">
-          <div class="control-group">
-            <label for="overlayLabel">Overlay Label</label>
-            <input type="text" id="overlayLabel" maxlength="32" />
-          </div>
-          <div class="control-group">
-            <label for="overlayAccent">Accent Colour</label>
-            <div class="accent-inputs" id="overlayAccentGroup">
-              <input type="color" id="overlayAccentPicker" aria-label="Accent colour" value="#ef4444" />
-              <input type="text" id="overlayAccent" placeholder="#ef4444" autocomplete="off" spellcheck="false" />
-            </div>
-            <p class="control-hint" id="overlayAccentHint">Accepts hex (#ff0000), rgb(a), hsl(a), or named colours.</p>
-          </div>
-          <div class="control-group">
-            <label for="highlightWords">Highlight Words (comma separated)</label>
-            <input type="text" id="highlightWords" placeholder="YouTube,Twitch,breaking" />
-          </div>
-        </div>
-        <div class="control-group">
-          <label for="scaleRange">Overlay Scale</label>
-          <div class="segment-row" style="flex-wrap: nowrap; gap: 12px; align-items: center;">
-            <input type="range" id="scaleRange" min="0.75" max="2.5" step="0.05" value="1.75" />
-            <input type="number" id="scaleNumber" min="0.75" max="2.5" step="0.05" value="1.75" style="max-width: 90px;" />
-          </div>
-        </div>
-        <div class="control-group">
-          <label for="popupScaleRange">Popup Scale</label>
-          <div class="segment-row" style="flex-wrap: nowrap; gap: 12px; align-items: center;">
-            <input type="range" id="popupScaleRange" min="0.6" max="1.5" step="0.05" value="1" />
-            <input type="number" id="popupScaleNumber" min="0.6" max="1.5" step="0.05" value="1" style="max-width: 90px;" />
-          </div>
-          <p class="control-hint">Shrink or grow the popup independently of the ticker.</p>
-        </div>
-        <div class="control-group">
-          <label>Position</label>
-          <div class="segment-row" id="positionButtons">
-            <button type="button" class="segment-button" data-position="bottom">Bottom</button>
-            <button type="button" class="segment-button" data-position="top">Top</button>
-          </div>
-        </div>
-        <div class="control-group">
-          <label>Animation Mode</label>
-          <div class="segment-row" id="modeButtons">
-            <button type="button" class="segment-button" data-mode="auto">Auto</button>
-            <button type="button" class="segment-button" data-mode="marquee">Marquee</button>
-            <button type="button" class="segment-button" data-mode="chunk">Chunk</button>
-          </div>
-        </div>
-        <div class="control-group">
-          <label>Theme</label>
-            <div class="segment-row" id="themeButtons">
-              <button type="button" class="segment-button" data-theme="holographic">Holographic</button>
-              <button type="button" class="segment-button" data-theme="neural">Neural</button>
-              <button type="button" class="segment-button" data-theme="quantum">Quantum</button>
-              <button type="button" class="segment-button" data-theme="crystalline">Crystalline</button>
-              <button type="button" class="segment-button" data-theme="neon-noir">Neon Noir</button>
-            </div>
-            <div class="theme-notes">
-              <span><strong>Holographic</strong> iridescent refraction with caustic light</span>
-              <span><strong>Neural</strong> AI-inspired circuitry with pulsing glow</span>
-              <span><strong>Quantum</strong> particle gradients and energetic beams</span>
-              <span><strong>Crystalline</strong> precision glass facets and cool sheen</span>
-              <span><strong>Neon Noir</strong> cyberpunk neon with deep contrast</span>
-            </div>
-        </div>
-        <div class="toggle-row">
-          <label><input type="checkbox" id="accentAnimToggle" checked /> Accent shimmer</label>
-          <label><input type="checkbox" id="sparkleToggle" checked /> Sparkle effects</label>
-        </div>
-        <div class="actions">
-          <button class="btn btn-ghost" id="copyOverlay">Copy URL</button>
-        </div>
-        <div class="preview-block">
-          <div class="preview-toolbar">
-            <div>
-              <div class="preview-title">Live Preview</div>
-              <div class="preview-sub">Embeds the overlay URL above so changes appear instantly.</div>
-            </div>
-            <div class="preview-actions">
-              <button type="button" class="btn btn-secondary" id="reloadPreview">Reload</button>
-              <button type="button" class="btn btn-ghost" id="openOverlay">Open in new tab</button>
-            </div>
-          </div>
-          <div class="preview-frame">
-            <iframe id="overlayPreview" title="Overlay preview" loading="lazy" sandbox="allow-same-origin allow-scripts"></iframe>
-          </div>
-        </div>
-      </section>
-
-      <section class="panel panel--neutral" id="slatePanel">
-        <div>
-          <div class="section-title">Segment Slate</div>
-          <div class="section-sub">Curate the compact top-right slate with UK time and short notices such as next-up cues or sponsor callouts.</div>
-        </div>
-        <div class="slate-panel-controls">
-          <div class="slate-toggles">
-            <label><input type="checkbox" id="slateEnabled" /> Enable segment slate</label>
-            <label><input type="checkbox" id="slateShowClock" /> Show clock</label>
-          </div>
-          <div class="slate-grid">
+          <div class="control-grid">
             <div class="control-group">
-              <label for="slateRotation">Rotation Interval (seconds)</label>
-              <div class="segment-row" style="gap: 12px; align-items: center;">
-                <input type="range" id="slateRotation" min="4" max="60" step="1" value="12" />
-                <input type="number" id="slateRotationNumber" min="4" max="60" step="1" value="12" style="max-width: 80px;" />
+              <label for="displayDuration">Display Duration (seconds)</label>
+              <input type="number" id="displayDuration" min="2" max="90" step="1" value="5" />
+            </div>
+            <div class="control-group">
+              <label for="intervalMinutes">Interval Between Messages (minutes)</label>
+              <input type="number" id="intervalMinutes" min="0" max="60" step="0.01" value="0" />
+            </div>
+          </div>
+          <div class="actions">
+            <button class="btn btn-success" id="startBtn">Start</button>
+            <button class="btn btn-danger" id="stopBtn">Stop</button>
+            <div class="spacer"></div>
+            <button class="btn btn-secondary" id="refreshBtn">Refresh</button>
+          </div>
+        </section>
+
+        <section class="panel panel--neutral" id="messagesPanel">
+          <div>
+            <div class="section-title">Ticker Messages</div>
+            <div class="section-sub">Use modifiers like <code>~~rainbow~~</code>, <code>%%spark%%</code>, <code>^^bounce^^</code>, <code>==neon==</code>, and <code>!!glitch!!</code>. Markdown-style <code>**bold**</code> and <code>*italic*</code> are supported.</div>
+          </div>
+          <form class="message-composer" id="messageForm">
+            <input type="text" id="newMessage" placeholder="Add a ticker message…" autocomplete="off" />
+            <button type="submit" class="btn" id="addMessageButton">Add</button>
+            <button type="button" class="btn btn-secondary" id="clearMessages">Clear</button>
+            <button type="button" class="btn btn-ghost" id="exportMessages">Export</button>
+            <button type="button" class="btn btn-ghost" id="importMessages">Import</button>
+          </form>
+          <div class="message-list" id="messageList">
+            <div class="empty-state">No messages yet — add a line above or load a preset.</div>
+          </div>
+        </section>
+
+        <section class="panel panel--muted" id="presetsPanel">
+          <div>
+            <div class="section-title">Message Presets</div>
+            <div class="section-sub">Save frequently used rotations. Loading replaces the current queue; appending pushes messages to the bottom.</div>
+          </div>
+          <div class="preset-header">
+            <input type="text" id="presetName" placeholder="Preset name" />
+            <button class="btn" type="button" id="savePreset">Save Current Messages</button>
+          </div>
+          <div class="preset-list" id="presetList">
+            <div class="empty-state">No presets saved yet.</div>
+          </div>
+        </section>
+
+        <section class="panel panel--accent" id="scenesPanel">
+          <div>
+            <div class="section-title">Scene Presets</div>
+            <div class="section-sub">Snapshot ticker queues with popup and theme settings so you can recall complete looks for recurring segments.</div>
+          </div>
+          <div class="scene-header">
+            <input type="text" id="sceneName" placeholder="Scene name" />
+            <button class="btn" type="button" id="saveScene">Save Scene</button>
+          </div>
+          <div class="scene-list" id="sceneList">
+            <div class="empty-state">No scenes saved yet.</div>
+          </div>
+        </section>
+      </div>
+
+      <div class="layout-col layout-col--secondary">
+        <section class="panel panel--accent" id="overlayPanel">
+          <div>
+            <div class="section-title">Overlay Styling</div>
+            <div class="section-sub">Adjust label, highlights, animation preferences, and scale for the browser source preview.</div>
+          </div>
+          <div class="control-grid">
+            <div class="control-group">
+              <label for="overlayLabel">Overlay Label</label>
+              <input type="text" id="overlayLabel" maxlength="32" />
+            </div>
+            <div class="control-group">
+              <label for="overlayAccent">Accent Colour</label>
+              <div class="accent-inputs" id="overlayAccentGroup">
+                <input type="color" id="overlayAccentPicker" aria-label="Accent colour" value="#ef4444" />
+                <input type="text" id="overlayAccent" placeholder="#ef4444" autocomplete="off" spellcheck="false" />
+              </div>
+              <p class="control-hint" id="overlayAccentHint">Accepts hex (#ff0000), rgb(a), hsl(a), or named colours.</p>
+            </div>
+            <div class="control-group">
+              <label for="highlightWords">Highlight Words (comma separated)</label>
+              <input type="text" id="highlightWords" placeholder="YouTube,Twitch,breaking" />
+            </div>
+          </div>
+          <div class="control-group">
+            <label for="scaleRange">Overlay Scale</label>
+            <div class="segment-row" style="flex-wrap: nowrap; gap: 12px; align-items: center;">
+              <input type="range" id="scaleRange" min="0.75" max="2.5" step="0.05" value="1.75" />
+              <input type="number" id="scaleNumber" min="0.75" max="2.5" step="0.05" value="1.75" style="max-width: 90px;" />
+            </div>
+          </div>
+          <div class="control-group">
+            <label for="popupScaleRange">Popup Scale</label>
+            <div class="segment-row" style="flex-wrap: nowrap; gap: 12px; align-items: center;">
+              <input type="range" id="popupScaleRange" min="0.6" max="1.5" step="0.05" value="1" />
+              <input type="number" id="popupScaleNumber" min="0.6" max="1.5" step="0.05" value="1" style="max-width: 90px;" />
+            </div>
+            <p class="control-hint">Shrink or grow the popup independently of the ticker.</p>
+          </div>
+          <div class="control-group">
+            <label>Position</label>
+            <div class="segment-row" id="positionButtons">
+              <button type="button" class="segment-button" data-position="bottom">Bottom</button>
+              <button type="button" class="segment-button" data-position="top">Top</button>
+            </div>
+          </div>
+          <div class="control-group">
+            <label>Animation Mode</label>
+            <div class="segment-row" id="modeButtons">
+              <button type="button" class="segment-button" data-mode="auto">Auto</button>
+              <button type="button" class="segment-button" data-mode="marquee">Marquee</button>
+              <button type="button" class="segment-button" data-mode="chunk">Chunk</button>
+            </div>
+          </div>
+          <div class="control-group">
+            <label>Theme</label>
+              <div class="segment-row" id="themeButtons">
+                <button type="button" class="segment-button" data-theme="holographic">Holographic</button>
+                <button type="button" class="segment-button" data-theme="neural">Neural</button>
+                <button type="button" class="segment-button" data-theme="quantum">Quantum</button>
+                <button type="button" class="segment-button" data-theme="crystalline">Crystalline</button>
+                <button type="button" class="segment-button" data-theme="neon-noir">Neon Noir</button>
+              </div>
+              <div class="theme-notes">
+                <span><strong>Holographic</strong> iridescent refraction with caustic light</span>
+                <span><strong>Neural</strong> AI-inspired circuitry with pulsing glow</span>
+                <span><strong>Quantum</strong> particle gradients and energetic beams</span>
+                <span><strong>Crystalline</strong> precision glass facets and cool sheen</span>
+                <span><strong>Neon Noir</strong> cyberpunk neon with deep contrast</span>
+              </div>
+          </div>
+          <div class="toggle-row">
+            <label><input type="checkbox" id="accentAnimToggle" checked /> Accent shimmer</label>
+            <label><input type="checkbox" id="sparkleToggle" checked /> Sparkle effects</label>
+          </div>
+          <div class="actions">
+            <button class="btn btn-ghost" id="copyOverlay">Copy URL</button>
+          </div>
+          <div class="preview-block">
+            <div class="preview-toolbar">
+              <div>
+                <div class="preview-title">Live Preview</div>
+                <div class="preview-sub">Embeds the overlay URL above so changes appear instantly.</div>
+              </div>
+              <div class="preview-actions">
+                <button type="button" class="btn btn-secondary" id="reloadPreview">Reload</button>
+                <button type="button" class="btn btn-ghost" id="openOverlay">Open in new tab</button>
               </div>
             </div>
-            <div class="control-group">
-              <label for="slateClockLabel">Clock label</label>
-              <input type="text" id="slateClockLabel" maxlength="48" placeholder="UK TIME" />
-            </div>
-            <div class="control-group">
-              <label for="slateNextLabel">Next-up label</label>
-              <input type="text" id="slateNextLabel" maxlength="48" placeholder="Next up" />
-            </div>
-            <div class="control-group">
-              <label for="slateNextTitle">Next-up title</label>
-              <input type="text" id="slateNextTitle" maxlength="64" placeholder="Guest interview" />
-            </div>
-            <div class="control-group">
-              <label for="slateNextSubtitle">Next-up details</label>
-              <input type="text" id="slateNextSubtitle" maxlength="200" placeholder="Happening after the break" />
-            </div>
-            <div class="control-group">
-              <label for="slateSponsorLabel">Sponsor label</label>
-              <input type="text" id="slateSponsorLabel" maxlength="48" placeholder="Sponsor" />
-            </div>
-            <div class="control-group">
-              <label for="slateSponsorName">Sponsor name</label>
-              <input type="text" id="slateSponsorName" maxlength="64" placeholder="Acme Co." />
-            </div>
-            <div class="control-group">
-              <label for="slateSponsorTagline">Sponsor tagline</label>
-              <input type="text" id="slateSponsorTagline" maxlength="200" placeholder="Proudly supporting tonight's stream" />
-            </div>
-            <div class="control-group">
-              <label for="slateNotesLabel">Spotlight label</label>
-              <input type="text" id="slateNotesLabel" maxlength="48" placeholder="Spotlight" />
-            </div>
-            <div class="control-group">
-              <label for="slateNotes">Spotlight notes (one per line)</label>
-              <textarea id="slateNotes" maxlength="600" placeholder="Follow @channelhandle&#10;Share your questions with #AskLive"></textarea>
-              <p class="control-hint">Up to six short lines rotate alongside the clock card.</p>
+            <div class="preview-frame">
+              <iframe id="overlayPreview" title="Overlay preview" loading="lazy" sandbox="allow-same-origin allow-scripts"></iframe>
             </div>
           </div>
-          <div class="slate-preview is-empty is-visible" id="slatePreview">
-            <div class="slate-preview-row" id="slatePreviewContent">
-              <span class="slate-preview-pill">Segment slate</span>
-              <div class="slate-preview-title">Add upcoming items or notes to preview the slate.</div>
-              <div class="slate-preview-subtitle">Clock and messages will rotate automatically.</div>
-              <div class="slate-preview-meta">Rotation preview</div>
-            </div>
-            <div class="slate-preview-dots" id="slatePreviewDots"></div>
-          </div>
-        </div>
-      </section>
+        </section>
 
-      <section class="panel panel--neutral" id="popupPanel">
-        <div>
-          <div class="section-title">Popup Message</div>
-          <div class="section-sub">Send a top-left callout styled like the ticker. Supports the same text modifiers.</div>
-        </div>
-        <textarea id="popupText" placeholder="Enter popup message…"></textarea>
-        <div class="popup-actions">
-          <label class="popup-toggle"><input type="checkbox" id="popupActive" /> Display popup</label>
-          <div class="popup-duration">
-            <label for="popupDuration">Auto-hide (seconds)</label>
-            <input type="number" id="popupDuration" min="0" max="600" step="1" placeholder="Leave blank to stay visible" inputmode="numeric" />
+        <section class="panel panel--neutral" id="slatePanel">
+          <div>
+            <div class="section-title">Segment Slate</div>
+            <div class="section-sub">Curate the compact top-right slate with UK time and short notices such as next-up cues or sponsor callouts.</div>
           </div>
-          <div class="popup-buttons">
-            <button class="btn btn-secondary" type="button" id="clearPopup">Clear</button>
-            <button class="btn" type="button" id="savePopup">Update Popup</button>
+          <div class="slate-panel-controls">
+            <div class="slate-toggles">
+              <label><input type="checkbox" id="slateEnabled" /> Enable segment slate</label>
+              <label><input type="checkbox" id="slateShowClock" /> Show clock</label>
+            </div>
+            <div class="slate-grid">
+              <div class="control-group">
+                <label for="slateRotation">Rotation Interval (seconds)</label>
+                <div class="segment-row" style="gap: 12px; align-items: center;">
+                  <input type="range" id="slateRotation" min="4" max="60" step="1" value="12" />
+                  <input type="number" id="slateRotationNumber" min="4" max="60" step="1" value="12" style="max-width: 80px;" />
+                </div>
+              </div>
+              <div class="control-group">
+                <label for="slateClockLabel">Clock label</label>
+                <input type="text" id="slateClockLabel" maxlength="48" placeholder="UK TIME" />
+              </div>
+              <div class="control-group">
+                <label for="slateNextLabel">Next-up label</label>
+                <input type="text" id="slateNextLabel" maxlength="48" placeholder="Next up" />
+              </div>
+              <div class="control-group">
+                <label for="slateNextTitle">Next-up title</label>
+                <input type="text" id="slateNextTitle" maxlength="64" placeholder="Guest interview" />
+              </div>
+              <div class="control-group">
+                <label for="slateNextSubtitle">Next-up details</label>
+                <input type="text" id="slateNextSubtitle" maxlength="200" placeholder="Happening after the break" />
+              </div>
+              <div class="control-group">
+                <label for="slateSponsorLabel">Sponsor label</label>
+                <input type="text" id="slateSponsorLabel" maxlength="48" placeholder="Sponsor" />
+              </div>
+              <div class="control-group">
+                <label for="slateSponsorName">Sponsor name</label>
+                <input type="text" id="slateSponsorName" maxlength="64" placeholder="Acme Co." />
+              </div>
+              <div class="control-group">
+                <label for="slateSponsorTagline">Sponsor tagline</label>
+                <input type="text" id="slateSponsorTagline" maxlength="200" placeholder="Proudly supporting tonight's stream" />
+              </div>
+              <div class="control-group">
+                <label for="slateNotesLabel">Spotlight label</label>
+                <input type="text" id="slateNotesLabel" maxlength="48" placeholder="Spotlight" />
+              </div>
+              <div class="control-group">
+                <label for="slateNotes">Spotlight notes (one per line)</label>
+                <textarea id="slateNotes" maxlength="600" placeholder="Follow @channelhandle&#10;Share your questions with #AskLive"></textarea>
+                <p class="control-hint">Up to six short lines rotate alongside the clock card.</p>
+              </div>
+            </div>
+            <div class="slate-preview is-empty is-visible" id="slatePreview">
+              <div class="slate-preview-row" id="slatePreviewContent">
+                <span class="slate-preview-pill">Segment slate</span>
+                <div class="slate-preview-title">Add upcoming items or notes to preview the slate.</div>
+                <div class="slate-preview-subtitle">Clock and messages will rotate automatically.</div>
+                <div class="slate-preview-meta">Rotation preview</div>
+              </div>
+              <div class="slate-preview-dots" id="slatePreviewDots"></div>
+            </div>
           </div>
-        </div>
-        <div class="popup-countdown">
-          <label class="popup-countdown-toggle"><input type="checkbox" id="popupCountdownEnabled" /> Append countdown timer</label>
-          <div class="popup-countdown-input">
-            <label for="popupCountdownTarget">Countdown target</label>
-            <input type="datetime-local" id="popupCountdownTarget" />
-          </div>
-        </div>
-        <div class="popup-preview is-empty" id="popupPreview">Popup preview</div>
-        <div class="popup-meta" id="popupMeta">Popup hidden</div>
-      </section>
+        </section>
 
-      <section class="panel panel--muted" id="brbPanel">
-        <div>
-          <div class="section-title">BRB Message</div>
-          <div class="section-sub">Manage the standby banner shared with the overlay output.</div>
-        </div>
-        <textarea id="brbText" placeholder="Enter BRB message…"></textarea>
-        <div class="brb-actions">
-          <label class="brb-toggle"><input type="checkbox" id="brbActive" /> Show BRB message</label>
-          <div class="spacer"></div>
-          <button class="btn btn-secondary" type="button" id="brbClear">Clear</button>
-          <button class="btn" type="button" id="brbSave">Update BRB</button>
-        </div>
-        <div class="brb-status" id="brbStatus">BRB hidden</div>
-      </section>
+        <section class="panel panel--neutral" id="popupPanel">
+          <div>
+            <div class="section-title">Popup Message</div>
+            <div class="section-sub">Send a top-left callout styled like the ticker. Supports the same text modifiers.</div>
+          </div>
+          <textarea id="popupText" placeholder="Enter popup message…"></textarea>
+          <div class="popup-actions">
+            <label class="popup-toggle"><input type="checkbox" id="popupActive" /> Display popup</label>
+            <div class="popup-duration">
+              <label for="popupDuration">Auto-hide (seconds)</label>
+              <input type="number" id="popupDuration" min="0" max="600" step="1" placeholder="Leave blank to stay visible" inputmode="numeric" />
+            </div>
+            <div class="popup-buttons">
+              <button class="btn btn-secondary" type="button" id="clearPopup">Clear</button>
+              <button class="btn" type="button" id="savePopup">Update Popup</button>
+            </div>
+          </div>
+          <div class="popup-countdown">
+            <label class="popup-countdown-toggle"><input type="checkbox" id="popupCountdownEnabled" /> Append countdown timer</label>
+            <div class="popup-countdown-input">
+              <label for="popupCountdownTarget">Countdown target</label>
+              <input type="datetime-local" id="popupCountdownTarget" />
+            </div>
+          </div>
+          <div class="popup-preview is-empty" id="popupPreview">Popup preview</div>
+          <div class="popup-meta" id="popupMeta">Popup hidden</div>
+        </section>
+
+        <section class="panel panel--muted" id="brbPanel">
+          <div>
+            <div class="section-title">BRB Message</div>
+            <div class="section-sub">Manage the standby banner shared with the overlay output.</div>
+          </div>
+          <textarea id="brbText" placeholder="Enter BRB message…"></textarea>
+          <div class="brb-actions">
+            <label class="brb-toggle"><input type="checkbox" id="brbActive" /> Show BRB message</label>
+            <div class="spacer"></div>
+            <button class="btn btn-secondary" type="button" id="brbClear">Clear</button>
+            <button class="btn" type="button" id="brbSave">Update BRB</button>
+          </div>
+          <div class="brb-status" id="brbStatus">BRB hidden</div>
+        </section>
+      </div>
     </div>
-
-    <section class="panel panel--neutral" id="messagesPanel">
-      <div>
-        <div class="section-title">Ticker Messages</div>
-        <div class="section-sub">Use modifiers like <code>~~rainbow~~</code>, <code>%%spark%%</code>, <code>^^bounce^^</code>, <code>==neon==</code>, and <code>!!glitch!!</code>. Markdown-style <code>**bold**</code> and <code>*italic*</code> are supported.</div>
-      </div>
-      <form class="message-composer" id="messageForm">
-        <input type="text" id="newMessage" placeholder="Add a ticker message…" autocomplete="off" />
-        <button type="submit" class="btn" id="addMessageButton">Add</button>
-        <button type="button" class="btn btn-secondary" id="clearMessages">Clear</button>
-        <button type="button" class="btn btn-ghost" id="exportMessages">Export</button>
-        <button type="button" class="btn btn-ghost" id="importMessages">Import</button>
-      </form>
-      <div class="message-list" id="messageList">
-        <div class="empty-state">No messages yet — add a line above or load a preset.</div>
-      </div>
-    </section>
-
-    <section class="panel panel--muted" id="presetsPanel">
-      <div>
-        <div class="section-title">Message Presets</div>
-        <div class="section-sub">Save frequently used rotations. Loading replaces the current queue; appending pushes messages to the bottom.</div>
-      </div>
-      <div class="preset-header">
-        <input type="text" id="presetName" placeholder="Preset name" />
-        <button class="btn" type="button" id="savePreset">Save Current Messages</button>
-      </div>
-      <div class="preset-list" id="presetList">
-        <div class="empty-state">No presets saved yet.</div>
-      </div>
-    </section>
-
-    <section class="panel panel--accent" id="scenesPanel">
-      <div>
-        <div class="section-title">Scene Presets</div>
-        <div class="section-sub">Snapshot ticker queues with popup and theme settings so you can recall complete looks for recurring segments.</div>
-      </div>
-      <div class="scene-header">
-        <input type="text" id="sceneName" placeholder="Scene name" />
-        <button class="btn" type="button" id="saveScene">Save Scene</button>
-      </div>
-      <div class="scene-list" id="sceneList">
-        <div class="empty-state">No scenes saved yet.</div>
-      </div>
-    </section>
   </div>
 
   <div class="preset-modal" id="presetMessageModal" aria-hidden="true">


### PR DESCRIPTION
## Summary
- expand the dashboard canvas and introduce a responsive dual-column layout with a sticky control rail
- refresh dark mode styling variables for a cleaner, more minimal presentation that still highlights key panels
- ensure existing ticker, popup, slate, and preset controls retain their behaviour within the new structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d47859b53883219da55fbd30183257