### PR TITLE
Tone down overlay glows

### DIFF
--- a/public/css/themes.css
+++ b/public/css/themes.css
@@ -75,9 +75,8 @@ body.ticker--glass {
       rgba(120, 255, 180, 0.4)
     );
   --ticker-shadow:
-    0 40px 100px rgba(8, 15, 35, 0.7),
-    0 0 80px rgba(120, 200, 255, 0.15),
-    0 0 120px rgba(255, 120, 200, 0.1);
+    0 24px 60px rgba(8, 15, 35, 0.5),
+    0 0 32px rgba(120, 200, 255, 0.14);
   --ticker-backdrop-filter: blur(24px) saturate(1.4) hue-rotate(5deg);
   --ticker-surface-noise: var(--noise-subtle);
   --ticker-ambient-mask:
@@ -109,9 +108,8 @@ body.ticker--glass {
   --ticker-label-letter: calc(2.5px * var(--ui-scale));
   --ticker-label-color: rgba(255, 255, 255, 0.98);
   --ticker-label-shadow:
-    0 0 15px rgba(120, 220, 255, 0.6),
-    0 0 30px rgba(255, 120, 220, 0.4),
-    0 2px 8px rgba(0, 0, 0, 0.6);
+    0 0 8px rgba(120, 220, 255, 0.38),
+    0 1px 5px rgba(0, 0, 0, 0.45);
   --ticker-divider-color:
     linear-gradient(90deg,
       rgba(120, 220, 255, 0.5),
@@ -131,9 +129,9 @@ body.ticker--glass {
     );
   --ticker-accent-border: 2px solid transparent;
   --ticker-accent-glow:
-    0 0 60px rgba(120, 220, 255, 0.4),
-    0 0 100px rgba(255, 120, 220, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    0 0 22px rgba(120, 220, 255, 0.28),
+    0 0 38px rgba(255, 120, 220, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22);
   --ticker-accent-animation: holographicShift 20s linear infinite;
   --popup-surface-a:
     linear-gradient(135deg,
@@ -154,8 +152,8 @@ body.ticker--glass {
       rgba(120, 255, 180, 0.35)
     );
   --popup-shadow:
-    0 50px 120px rgba(8, 15, 35, 0.65),
-    0 0 90px rgba(120, 200, 255, 0.2);
+    0 28px 72px rgba(8, 15, 35, 0.5),
+    0 0 36px rgba(120, 200, 255, 0.16);
   --popup-text-color: rgba(250, 252, 255, 0.98);
   --popup-divider-color: rgba(180, 220, 255, 0.4);
   --popup-countdown-color: rgba(240, 245, 255, 0.95);
@@ -184,9 +182,8 @@ body.ticker--mono {
   --ticker-surface-b: rgba(8, 10, 16, 0.96);
   --ticker-border: rgba(0, 255, 150, 0.25);
   --ticker-shadow:
-    0 35px 90px rgba(5, 8, 15, 0.8),
-    0 0 60px rgba(0, 255, 150, 0.12),
-    0 0 120px rgba(0, 180, 255, 0.08);
+    0 20px 52px rgba(5, 8, 15, 0.52),
+    0 0 28px rgba(0, 255, 150, 0.12);
   --ticker-backdrop-filter: blur(20px) saturate(1.3);
   --ticker-surface-noise: var(--noise-grain);
   --ticker-ambient-mask:
@@ -223,9 +220,8 @@ body.ticker--mono {
   --ticker-label-letter: calc(1.5px * var(--ui-scale));
   --ticker-label-color: rgba(240, 255, 248, 0.96);
   --ticker-label-shadow:
-    0 0 12px rgba(0, 255, 150, 0.6),
-    0 0 24px rgba(0, 180, 255, 0.3),
-    0 1px 6px rgba(0, 0, 0, 0.7);
+    0 0 7px rgba(0, 255, 150, 0.32),
+    0 1px 5px rgba(0, 0, 0, 0.5);
   --ticker-divider-color: rgba(0, 255, 150, 0.4);
   --ticker-accent-overlay:
     radial-gradient(ellipse 120% 200% at 40% 0%,
@@ -246,16 +242,16 @@ body.ticker--mono {
     );
   --ticker-accent-border: 1px solid rgba(0, 255, 150, 0.4);
   --ticker-accent-glow:
-    0 0 40px rgba(0, 255, 150, 0.3),
-    0 0 80px rgba(0, 180, 255, 0.15),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+    0 0 18px rgba(0, 255, 150, 0.24),
+    0 0 30px rgba(0, 180, 255, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
   --ticker-accent-animation: neuralPulse 12s var(--ease-circ) infinite;
   --popup-surface-a: rgba(18, 22, 30, 0.92);
   --popup-surface-b: rgba(10, 12, 20, 0.94);
   --popup-border-color: rgba(0, 255, 150, 0.3);
   --popup-shadow:
-    0 40px 100px rgba(5, 8, 15, 0.75),
-    0 0 70px rgba(0, 255, 150, 0.15);
+    0 24px 64px rgba(5, 8, 15, 0.52),
+    0 0 30px rgba(0, 255, 150, 0.12);
   --popup-text-color: rgba(245, 252, 248, 0.97);
   --popup-divider-color: rgba(0, 255, 150, 0.35);
   --popup-countdown-color: rgba(235, 250, 242, 0.94);
@@ -287,9 +283,8 @@ body.ticker--headline {
     rgba(5, 3, 12, 0.98);
   --ticker-border: rgba(180, 100, 255, 0.3);
   --ticker-shadow:
-    0 45px 120px rgba(8, 4, 20, 0.8),
-    0 0 100px rgba(180, 100, 255, 0.2),
-    0 0 200px rgba(100, 150, 255, 0.1);
+    0 26px 70px rgba(8, 4, 20, 0.55),
+    0 0 36px rgba(180, 100, 255, 0.16);
   --ticker-backdrop-filter: blur(22px) saturate(1.5) contrast(1.1);
   --ticker-surface-noise: var(--noise-subtle);
   --ticker-ambient-mask:
@@ -326,9 +321,8 @@ body.ticker--headline {
   --ticker-label-letter: calc(2px * var(--ui-scale));
   --ticker-label-color: rgba(250, 245, 255, 0.98);
   --ticker-label-shadow:
-    0 0 15px rgba(180, 100, 255, 0.7),
-    0 0 30px rgba(100, 150, 255, 0.4),
-    0 2px 10px rgba(0, 0, 0, 0.8);
+    0 0 9px rgba(180, 100, 255, 0.4),
+    0 1px 6px rgba(0, 0, 0, 0.6);
   --ticker-divider-color:
     linear-gradient(45deg,
       rgba(180, 100, 255, 0.5),
@@ -353,10 +347,9 @@ body.ticker--headline {
     );
   --ticker-accent-border: 2px solid rgba(180, 100, 255, 0.4);
   --ticker-accent-glow:
-    0 0 50px rgba(180, 100, 255, 0.4),
-    0 0 100px rgba(100, 150, 255, 0.2),
-    0 0 150px rgba(150, 120, 255, 0.15),
-    inset 0 2px 0 rgba(255, 255, 255, 0.2);
+    0 0 24px rgba(180, 100, 255, 0.28),
+    0 0 42px rgba(100, 150, 255, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
   --ticker-accent-animation: quantumFlux 20s var(--ease-premium) infinite;
   --popup-surface-a:
     radial-gradient(ellipse at top, rgba(30, 20, 50, 0.88), rgba(20, 12, 35, 0.92)),
@@ -365,8 +358,8 @@ body.ticker--headline {
     radial-gradient(ellipse at bottom, rgba(15, 8, 30, 0.94), rgba(12, 6, 22, 0.96));
   --popup-border-color: rgba(180, 100, 255, 0.35);
   --popup-shadow:
-    0 50px 130px rgba(8, 4, 20, 0.75),
-    0 0 80px rgba(180, 100, 255, 0.25);
+    0 30px 80px rgba(8, 4, 20, 0.55),
+    0 0 36px rgba(180, 100, 255, 0.18);
   --popup-text-color: rgba(248, 245, 255, 0.98);
   --popup-divider-color: rgba(180, 120, 255, 0.4);
   --popup-countdown-color: rgba(245, 240, 255, 0.96);
@@ -397,9 +390,8 @@ body.ticker--minimal {
     linear-gradient(300deg, rgba(6, 10, 18, 0.98), rgba(10, 15, 25, 0.96));
   --ticker-border: rgba(100, 200, 255, 0.4);
   --ticker-shadow:
-    0 30px 80px rgba(5, 10, 20, 0.7),
-    0 0 60px rgba(100, 200, 255, 0.15),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    0 20px 56px rgba(5, 10, 20, 0.5),
+    0 0 28px rgba(100, 200, 255, 0.14);
   --ticker-backdrop-filter: blur(18px) saturate(1.2) brightness(1.05);
   --ticker-surface-noise: none;
   --ticker-ambient-mask:
@@ -438,8 +430,8 @@ body.ticker--minimal {
   --ticker-label-letter: calc(1px * var(--ui-scale));
   --ticker-label-color: rgba(245, 250, 255, 0.95);
   --ticker-label-shadow:
-    0 0 8px rgba(100, 200, 255, 0.5),
-    0 1px 4px rgba(0, 0, 0, 0.5);
+    0 0 5px rgba(100, 200, 255, 0.32),
+    0 1px 4px rgba(0, 0, 0, 0.45);
   --ticker-divider-color: rgba(120, 190, 255, 0.3);
   --ticker-accent-overlay:
     linear-gradient(45deg,
@@ -456,9 +448,9 @@ body.ticker--minimal {
     );
   --ticker-accent-border: 1px solid rgba(120, 190, 255, 0.5);
   --ticker-accent-glow:
-    0 0 25px rgba(100, 200, 255, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.2),
-    inset 0 -1px 0 rgba(100, 200, 255, 0.1);
+    0 0 16px rgba(100, 200, 255, 0.26),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 rgba(100, 200, 255, 0.08);
   --ticker-accent-animation: crystallineRefraction 18s linear infinite;
   --popup-surface-a:
     linear-gradient(120deg, rgba(15, 22, 32, 0.92), rgba(22, 30, 42, 0.88));
@@ -466,8 +458,8 @@ body.ticker--minimal {
     linear-gradient(300deg, rgba(8, 12, 22, 0.95), rgba(12, 18, 30, 0.92));
   --popup-border-color: rgba(120, 190, 255, 0.35);
   --popup-shadow:
-    0 35px 90px rgba(5, 10, 20, 0.65),
-    0 0 50px rgba(100, 200, 255, 0.2);
+    0 24px 68px rgba(5, 10, 20, 0.52),
+    0 0 28px rgba(100, 200, 255, 0.16);
   --popup-text-color: rgba(242, 248, 255, 0.96);
   --popup-divider-color: rgba(130, 180, 255, 0.3);
   --popup-countdown-color: rgba(238, 245, 255, 0.94);
@@ -495,9 +487,8 @@ body.ticker--contrast {
   --ticker-surface-b: rgba(4, 2, 8, 0.98);
   --ticker-border: rgba(255, 0, 120, 0.4);
   --ticker-shadow:
-    0 50px 140px rgba(4, 2, 10, 0.9),
-    0 0 100px rgba(255, 0, 120, 0.25),
-    0 0 200px rgba(0, 255, 200, 0.15);
+    0 28px 80px rgba(4, 2, 10, 0.6),
+    0 0 36px rgba(255, 0, 120, 0.2);
   --ticker-backdrop-filter: blur(24px) saturate(1.6) contrast(1.2);
   --ticker-surface-noise: var(--noise-grain);
   --ticker-ambient-mask:
@@ -540,9 +531,8 @@ body.ticker--contrast {
   --ticker-label-letter: calc(2px * var(--ui-scale));
   --ticker-label-color: rgba(255, 248, 252, 0.98);
   --ticker-label-shadow:
-    0 0 18px rgba(255, 0, 120, 0.55),
-    0 0 30px rgba(0, 255, 200, 0.35),
-    0 2px 10px rgba(0, 0, 0, 0.85);
+    0 0 10px rgba(255, 0, 120, 0.38),
+    0 1px 6px rgba(0, 0, 0, 0.65);
   --ticker-divider-color: rgba(255, 0, 120, 0.5);
   --ticker-accent-overlay:
     linear-gradient(160deg,
@@ -557,16 +547,16 @@ body.ticker--contrast {
     );
   --ticker-accent-border: 2px solid rgba(255, 0, 120, 0.45);
   --ticker-accent-glow:
-    0 0 65px rgba(255, 0, 120, 0.45),
-    0 0 120px rgba(0, 255, 200, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    0 0 26px rgba(255, 0, 120, 0.32),
+    0 0 44px rgba(0, 255, 200, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
   --ticker-accent-animation: neonNoirSweep 16s linear infinite;
   --popup-surface-a: rgba(14, 6, 20, 0.95);
   --popup-surface-b: rgba(8, 4, 12, 0.98);
   --popup-border-color: rgba(255, 0, 120, 0.35);
   --popup-shadow:
-    0 48px 130px rgba(4, 2, 10, 0.85),
-    0 0 120px rgba(255, 0, 120, 0.25);
+    0 28px 82px rgba(4, 2, 10, 0.6),
+    0 0 38px rgba(255, 0, 120, 0.22);
   --popup-text-color: rgba(255, 245, 250, 0.99);
   --popup-divider-color: rgba(255, 0, 120, 0.4);
   --popup-countdown-color: rgba(250, 240, 248, 0.97);
@@ -616,8 +606,8 @@ body.ticker--contrast {
 }
 
 @keyframes holographicPulse {
-  0%, 100% { opacity: 0.82; filter: saturate(1); }
-  40% { opacity: 1; filter: saturate(1.12); }
+  0%, 100% { opacity: 0.6; filter: saturate(1); }
+  40% { opacity: 0.8; filter: saturate(1.06); }
 }
 
 @keyframes neuralPulse {
@@ -633,8 +623,8 @@ body.ticker--contrast {
 }
 
 @keyframes neuralSync {
-  0%, 100% { box-shadow: 0 0 40px rgba(0, 255, 150, 0.25), 0 0 80px rgba(0, 180, 255, 0.15); }
-  50% { box-shadow: 0 0 70px rgba(0, 255, 150, 0.35), 0 0 120px rgba(0, 180, 255, 0.2); }
+  0%, 100% { box-shadow: 0 0 18px rgba(0, 255, 150, 0.2), 0 0 32px rgba(0, 180, 255, 0.12); }
+  50% { box-shadow: 0 0 28px rgba(0, 255, 150, 0.26), 0 0 44px rgba(0, 180, 255, 0.16); }
 }
 
 @keyframes ambientFlow {
@@ -655,8 +645,8 @@ body.ticker--contrast {
 }
 
 @keyframes quantumResonance {
-  0%, 100% { box-shadow: 0 0 45px rgba(180, 100, 255, 0.35), 0 0 120px rgba(100, 150, 255, 0.2); }
-  50% { box-shadow: 0 0 80px rgba(180, 100, 255, 0.45), 0 0 160px rgba(100, 150, 255, 0.28); }
+  0%, 100% { box-shadow: 0 0 22px rgba(180, 100, 255, 0.26), 0 0 48px rgba(100, 150, 255, 0.16); }
+  50% { box-shadow: 0 0 32px rgba(180, 100, 255, 0.32), 0 0 60px rgba(100, 150, 255, 0.2); }
 }
 
 @keyframes crystallineRefraction {
@@ -682,8 +672,8 @@ body.ticker--contrast {
 }
 
 @keyframes neonNoirPulse {
-  0%, 100% { box-shadow: 0 0 60px rgba(255, 0, 120, 0.4), 0 0 120px rgba(0, 255, 200, 0.25); }
-  45% { box-shadow: 0 0 90px rgba(255, 0, 120, 0.5), 0 0 160px rgba(0, 255, 200, 0.32); }
+  0%, 100% { box-shadow: 0 0 24px rgba(255, 0, 120, 0.3), 0 0 44px rgba(0, 255, 200, 0.18); }
+  45% { box-shadow: 0 0 34px rgba(255, 0, 120, 0.36), 0 0 56px rgba(0, 255, 200, 0.22); }
 }
 
 @keyframes textScramble {
@@ -693,7 +683,7 @@ body.ticker--contrast {
 }
 
 @keyframes tickerAmbientGlow {
-  0%, 100% { opacity: 0.45; filter: saturate(1) brightness(1); }
-  40% { opacity: 0.65; filter: saturate(1.08) brightness(1.05); }
-  70% { opacity: 0.55; filter: saturate(1.02) brightness(1.02); }
+  0%, 100% { opacity: 0.22; filter: saturate(1) brightness(1); }
+  40% { opacity: 0.32; filter: saturate(1.04) brightness(1.03); }
+  70% { opacity: 0.26; filter: saturate(1.02) brightness(1.01); }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -435,7 +435,7 @@
       font-size: calc(var(--text-lg) * var(--popup-scale) / var(--ui-scale));
       font-weight: 600;
       line-height: 1.45;
-      box-shadow: var(--popup-shadow, 0 22px 52px rgba(5, 8, 22, 0.5)), var(--ticker-chromatic-shadows, 0 0 0 transparent);
+      box-shadow: var(--popup-shadow, 0 16px 40px rgba(5, 8, 22, 0.42)), var(--ticker-chromatic-shadows, 0 0 0 transparent);
       min-height: 64px;
       overflow: hidden;
       transition: padding 0.2s var(--ease-smooth), font-size 0.2s var(--ease-smooth);
@@ -458,7 +458,7 @@
       --ticker-surface-a: rgba(18, 20, 28, 0.92);
       --ticker-surface-b: rgba(8, 10, 16, 0.9);
       --ticker-border: rgba(118, 134, 189, 0.28);
-      --ticker-shadow: 0 22px 52px rgba(5, 8, 22, 0.5);
+      --ticker-shadow: 0 14px 38px rgba(5, 8, 22, 0.42);
       --ticker-divider-color: rgba(255, 255, 255, 0.16);
       --popup-surface-a: color-mix(in srgb, var(--ticker-surface-a) 92%, rgba(255, 255, 255, 0.02));
       --popup-surface-b: color-mix(in srgb, var(--ticker-surface-b) 92%, rgba(0, 0, 0, 0.08));
@@ -470,7 +470,7 @@
       --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.52) 75%, var(--accent) 25%);
       --popup-accent-strip:
         linear-gradient(165deg, var(--accent), color-mix(in srgb, var(--accent) 32%, rgba(255, 255, 255, 0.45)));
-      --popup-sheen: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0) 65%);
+      --popup-sheen: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0) 65%);
     }
     .popup-preview::before {
       content: '';
@@ -480,7 +480,7 @@
       bottom: 0;
       width: calc(4px * var(--popup-scale));
       background: var(--popup-accent-strip);
-      opacity: 0.9;
+      opacity: 0.7;
       pointer-events: none;
     }
     .popup-preview::after {
@@ -490,7 +490,7 @@
       background:
         var(--ticker-ambient-caustics, transparent),
         var(--popup-sheen);
-      opacity: 0.4;
+      opacity: 0.18;
       pointer-events: none;
       animation: var(--popup-glow-anim, none);
       mix-blend-mode: screen;
@@ -760,8 +760,8 @@
       animation: rainbowShift 3.6s linear infinite, subtleFloat 2s ease-in-out infinite;
       animation-delay: calc(var(--i) * -0.12s), calc(var(--i) * 0.08s);
       text-shadow:
-        0 0 6px color-mix(in srgb, var(--accent) 32%, rgba(255, 255, 255, 0.35)),
-        0 0 16px color-mix(in srgb, var(--accent-glow) 45%, rgba(0, 0, 0, 0.15));
+        0 0 3px color-mix(in srgb, var(--accent) 26%, rgba(255, 255, 255, 0.25)),
+        0 0 8px color-mix(in srgb, var(--accent-glow) 35%, rgba(0, 0, 0, 0.12));
       filter: saturate(1.08) brightness(1.04);
     }
     .fx-sparkle .fx-letter {
@@ -777,8 +777,8 @@
       animation: sparkleShift 4.2s linear infinite, subtleFloat 1.9s ease-in-out infinite;
       animation-delay: calc(var(--i) * -0.1s), calc(var(--i) * 0.07s);
       text-shadow:
-        0 0 8px color-mix(in srgb, var(--accent) 35%, rgba(255, 255, 255, 0.4)),
-        0 0 18px color-mix(in srgb, var(--accent-glow) 30%, rgba(0, 0, 0, 0.2));
+        0 0 4px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.3)),
+        0 0 10px color-mix(in srgb, var(--accent-glow) 24%, rgba(0, 0, 0, 0.16));
       filter: saturate(1.1) contrast(1.05);
     }
 
@@ -792,7 +792,7 @@
       background-position: 0% 50%;
       animation: rainbowShift 3.6s linear infinite, subtleFloat 2s ease-in-out infinite;
       animation-delay: calc(var(--i) * -0.12s), calc(var(--i) * 0.08s);
-      text-shadow: 0 0 6px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.3));
+      text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 22%, rgba(255, 255, 255, 0.25));
       filter: saturate(1.05) brightness(1.03);
     }
 
@@ -806,9 +806,9 @@
     .fx-neon {
       color: color-mix(in srgb, var(--accent-bright) 72%, white 28%);
       text-shadow:
-        0 0 3px color-mix(in srgb, var(--accent) 60%, rgba(255, 255, 255, 0.35)),
-        0 0 12px color-mix(in srgb, var(--accent-glow) 55%, rgba(10, 14, 26, 0.5)),
-        0 0 22px color-mix(in srgb, var(--accent) 35%, rgba(0, 0, 0, 0.2));
+        0 0 2px color-mix(in srgb, var(--accent) 50%, rgba(255, 255, 255, 0.32)),
+        0 0 6px color-mix(in srgb, var(--accent-glow) 40%, rgba(10, 14, 26, 0.4)),
+        0 0 12px color-mix(in srgb, var(--accent) 28%, rgba(0, 0, 0, 0.18));
       animation: neonFlicker 3.4s ease-in-out infinite, gentlePulse 5.2s ease-in-out infinite;
     }
 
@@ -870,15 +870,15 @@
     @keyframes neonFlicker {
       0%, 100% {
         text-shadow:
-          0 0 2px color-mix(in srgb, var(--accent) 65%, rgba(255, 255, 255, 0.32)),
-          0 0 8px color-mix(in srgb, var(--accent-glow) 60%, rgba(12, 16, 28, 0.5)),
-          0 0 16px color-mix(in srgb, var(--accent) 45%, rgba(0, 0, 0, 0.2));
+          0 0 1px color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.28)),
+          0 0 4px color-mix(in srgb, var(--accent-glow) 48%, rgba(12, 16, 28, 0.4)),
+          0 0 8px color-mix(in srgb, var(--accent) 36%, rgba(0, 0, 0, 0.18));
       }
       50% {
         text-shadow:
-          0 0 4px color-mix(in srgb, var(--accent-bright) 80%, rgba(255, 255, 255, 0.4)),
-          0 0 14px color-mix(in srgb, var(--accent-glow) 70%, rgba(10, 14, 26, 0.35)),
-          0 0 26px color-mix(in srgb, var(--accent) 45%, rgba(0, 0, 0, 0.25));
+          0 0 2px color-mix(in srgb, var(--accent-bright) 70%, rgba(255, 255, 255, 0.36)),
+          0 0 6px color-mix(in srgb, var(--accent-glow) 60%, rgba(10, 14, 26, 0.3)),
+          0 0 12px color-mix(in srgb, var(--accent) 40%, rgba(0, 0, 0, 0.2));
       }
     }
     @keyframes dataGlitch {

--- a/public/output.html
+++ b/public/output.html
@@ -30,26 +30,26 @@
       --surface-border: rgba(255, 255, 255, 0.12);
       --surface-outline: rgba(255, 255, 255, 0.06);
       --text: #fefefe;
-      --shadow: 0 26px 68px rgba(3, 5, 14, 0.65);
+      --shadow: 0 18px 52px rgba(3, 5, 14, 0.5);
       --marquee-pps: 110;
       --hide-shift: calc(12px * var(--ui-scale) / 1.75);
       --ticker-surface-a: var(--surface-a);
       --ticker-surface-b: var(--surface-b);
       --ticker-border: var(--surface-outline);
-      --ticker-shadow: var(--shadow);
+      --ticker-shadow: 0 14px 38px rgba(3, 5, 14, 0.42);
       --ticker-label-width: var(--label-width);
       --ticker-label-size: calc(12px * var(--ui-scale));
       --ticker-label-weight: 700;
       --ticker-label-letter: calc(1px * var(--ui-scale));
       --ticker-label-case: uppercase;
       --ticker-label-color: #ffffff;
-      --ticker-label-shadow: 0 2px 4px rgba(0, 0, 0, 0.55);
+      --ticker-label-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
       --ticker-divider-color: rgba(255, 255, 255, 0.32);
       --ticker-accent-overlay:
         linear-gradient(155deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 62%),
         linear-gradient(150deg, var(--accent-bright), var(--accent-muted));
       --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.35));
-      --ticker-accent-glow: 0 0 26px color-mix(in srgb, var(--accent) 35%, rgba(255, 255, 255, 0.4));
+      --ticker-accent-glow: 0 0 12px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.25));
       --ticker-accent-animation: holographicShift 20s var(--ease-premium) infinite;
       --popup-surface-a: color-mix(in srgb, var(--ticker-surface-a) 92%, rgba(255, 255, 255, 0.02));
       --popup-surface-b: color-mix(in srgb, var(--ticker-surface-b) 92%, rgba(0, 0, 0, 0.08));
@@ -161,7 +161,7 @@
         var(--ticker-ambient-caustics, transparent),
         var(--ticker-surface-noise, none);
       mix-blend-mode: screen;
-      opacity: 0.55;
+      opacity: 0.22;
       animation: tickerAmbientGlow 12s var(--ease-smooth) infinite;
       z-index: 0;
     }
@@ -205,7 +205,7 @@
       font-size: calc(14px * var(--ui-scale));
       font-weight: 500;
       padding-left: var(--padding-x);
-      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
       transform: translate3d(0, 0, 0);
       will-change: transform;
     }
@@ -246,8 +246,8 @@
       animation: rainbowShift 3.6s linear infinite, subtleFloat 2s ease-in-out infinite;
       animation-delay: calc(var(--i) * -0.12s), calc(var(--i) * 0.08s);
       text-shadow:
-        0 0 6px color-mix(in srgb, var(--accent) 32%, rgba(255, 255, 255, 0.35)),
-        0 0 16px color-mix(in srgb, var(--accent-glow) 45%, rgba(0, 0, 0, 0.15));
+        0 0 3px color-mix(in srgb, var(--accent) 26%, rgba(255, 255, 255, 0.25)),
+        0 0 8px color-mix(in srgb, var(--accent-glow) 35%, rgba(0, 0, 0, 0.12));
       filter: saturate(1.08) brightness(1.04);
     }
 
@@ -266,8 +266,8 @@
       animation: sparkleShift 4.2s linear infinite, subtleFloat 1.9s ease-in-out infinite;
       animation-delay: calc(var(--i) * -0.1s), calc(var(--i) * 0.07s);
       text-shadow:
-        0 0 8px color-mix(in srgb, var(--accent) 35%, rgba(255, 255, 255, 0.4)),
-        0 0 18px color-mix(in srgb, var(--accent-glow) 30%, rgba(0, 0, 0, 0.2));
+        0 0 4px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.3)),
+        0 0 10px color-mix(in srgb, var(--accent-glow) 24%, rgba(0, 0, 0, 0.16));
       filter: saturate(1.1) contrast(1.05);
     }
 
@@ -281,7 +281,7 @@
       background-position: 0% 50%;
       animation: rainbowShift 3.6s linear infinite, subtleFloat 2s ease-in-out infinite;
       animation-delay: calc(var(--i) * -0.12s), calc(var(--i) * 0.08s);
-      text-shadow: 0 0 6px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.3));
+      text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 22%, rgba(255, 255, 255, 0.25));
       filter: saturate(1.05) brightness(1.03);
     }
 
@@ -295,9 +295,9 @@
     .fx-neon {
       color: color-mix(in srgb, var(--accent-bright) 72%, white 28%);
       text-shadow:
-        0 0 3px color-mix(in srgb, var(--accent) 60%, rgba(255, 255, 255, 0.35)),
-        0 0 12px color-mix(in srgb, var(--accent-glow) 55%, rgba(10, 14, 26, 0.5)),
-        0 0 22px color-mix(in srgb, var(--accent) 35%, rgba(0, 0, 0, 0.2));
+        0 0 2px color-mix(in srgb, var(--accent) 50%, rgba(255, 255, 255, 0.32)),
+        0 0 6px color-mix(in srgb, var(--accent-glow) 40%, rgba(10, 14, 26, 0.4)),
+        0 0 12px color-mix(in srgb, var(--accent) 28%, rgba(0, 0, 0, 0.18));
       animation: neonFlicker 3.4s ease-in-out infinite, gentlePulse 5.2s ease-in-out infinite;
     }
 
@@ -411,7 +411,7 @@
       position: absolute;
       inset: 0;
       background: var(--popup-sheen);
-      opacity: 0.35;
+      opacity: 0.18;
       pointer-events: none;
       mix-blend-mode: screen;
     }
@@ -472,7 +472,7 @@
       position: absolute;
       inset: 0;
       background: var(--popup-sheen);
-      opacity: 0.25;
+      opacity: 0.14;
       mix-blend-mode: screen;
       pointer-events: none;
     }
@@ -584,15 +584,15 @@
     @keyframes neonFlicker {
       0%, 100% {
         text-shadow:
-          0 0 2px color-mix(in srgb, var(--accent) 65%, rgba(255, 255, 255, 0.32)),
-          0 0 8px color-mix(in srgb, var(--accent-glow) 60%, rgba(12, 16, 28, 0.5)),
-          0 0 16px color-mix(in srgb, var(--accent) 45%, rgba(0, 0, 0, 0.2));
+          0 0 1px color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.28)),
+          0 0 4px color-mix(in srgb, var(--accent-glow) 48%, rgba(12, 16, 28, 0.4)),
+          0 0 8px color-mix(in srgb, var(--accent) 36%, rgba(0, 0, 0, 0.18));
       }
       50% {
         text-shadow:
-          0 0 4px color-mix(in srgb, var(--accent-bright) 80%, rgba(255, 255, 255, 0.4)),
-          0 0 14px color-mix(in srgb, var(--accent-glow) 70%, rgba(10, 14, 26, 0.35)),
-          0 0 26px color-mix(in srgb, var(--accent) 45%, rgba(0, 0, 0, 0.25));
+          0 0 2px color-mix(in srgb, var(--accent-bright) 70%, rgba(255, 255, 255, 0.36)),
+          0 0 6px color-mix(in srgb, var(--accent-glow) 60%, rgba(10, 14, 26, 0.3)),
+          0 0 12px color-mix(in srgb, var(--accent) 40%, rgba(0, 0, 0, 0.2));
       }
     }
 
@@ -608,8 +608,8 @@
     }
 
     @keyframes labelPulse {
-      0%, 100% { text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6); }
-      50% { text-shadow: 0 0 12px rgba(255, 255, 255, 0.6); }
+      0%, 100% { text-shadow: 0 1px 3px rgba(0, 0, 0, 0.45); }
+      50% { text-shadow: 0 0 6px rgba(255, 255, 255, 0.48); }
     }
 
     @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- soften the base ticker, popup, and slate styling to replace intense glow shadows with subtler treatments
- reduce glow-heavy variables and animations across all overlay themes to keep each widget restrained
- align the dashboard preview text effects and overlays with the tempered glow levels used in the live output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d54313c36c8321970af35391198245