### PR TITLE
Remove scaling from ticker animations

### DIFF
--- a/public/css/themes.css
+++ b/public/css/themes.css
@@ -639,9 +639,9 @@ body.ticker--contrast {
 }
 
 @keyframes particleWave {
-  0%, 100% { transform: translateY(0) scale(1); }
-  35% { transform: translateY(-4px) scale(1.04); }
-  65% { transform: translateY(2px) scale(0.98); }
+  0%, 100% { transform: translateY(0); }
+  35% { transform: translateY(-4px); }
+  65% { transform: translateY(2px); }
 }
 
 @keyframes quantumResonance {

--- a/public/index.html
+++ b/public/index.html
@@ -891,14 +891,14 @@
       50% { transform: translateY(-1px); }
     }
     @keyframes gentlePulse {
-      0%, 100% { transform: scale(1); }
-      50% { transform: scale(1.02); }
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-1px); }
     }
     @keyframes enhancedBounce {
-      0%, 100% { transform: translateY(0) scale(1); }
-      30% { transform: translateY(-3px) scale(1.03, 0.98); }
-      55% { transform: translateY(-4px) scale(1.05, 0.96); }
-      75% { transform: translateY(-1px) scale(1.01, 0.99); }
+      0%, 100% { transform: translateY(0); }
+      30% { transform: translateY(-3px); }
+      55% { transform: translateY(-4px); }
+      75% { transform: translateY(-1px); }
     }
     @keyframes neonFlicker {
       0%, 100% {

--- a/public/output.html
+++ b/public/output.html
@@ -570,15 +570,15 @@
     }
 
     @keyframes gentlePulse {
-      0%, 100% { transform: scale(1); }
-      50% { transform: scale(1.02); }
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-1px); }
     }
 
     @keyframes enhancedBounce {
-      0%, 100% { transform: translateY(0) scale(1); }
-      30% { transform: translateY(-3px) scale(1.03, 0.98); }
-      55% { transform: translateY(-4px) scale(1.05, 0.96); }
-      75% { transform: translateY(-1px) scale(1.01, 0.99); }
+      0%, 100% { transform: translateY(0); }
+      30% { transform: translateY(-3px); }
+      55% { transform: translateY(-4px); }
+      75% { transform: translateY(-1px); }
     }
 
     @keyframes neonFlicker {


### PR DESCRIPTION
## Summary
- remove scale transforms from the ticker wave animation so its size stays constant
- adjust the gentle pulse and enhanced bounce keyframes in the editor and overlay to rely on translation only

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5696c56d88321a9a620a6659346ee