### PR TITLE
Add liquid glass theme across overlay widgets

### DIFF
--- a/public/css/themes.css
+++ b/public/css/themes.css
@@ -173,6 +173,120 @@ body.ticker--glass {
   --popup-glow-anim: holographicPulse 8s var(--ease-premium) infinite;
 }
 
+/* LIQUID GLASS THEME - Soft frosted layers with saturated highlights */
+.ticker--liquid-glass,
+body.ticker--liquid-glass {
+  --ticker-surface-a:
+    linear-gradient(135deg,
+      rgba(255, 255, 255, 0.82),
+      rgba(236, 238, 244, 0.86),
+      rgba(214, 220, 236, 0.88)
+    );
+  --ticker-surface-b:
+    linear-gradient(225deg,
+      rgba(226, 234, 248, 0.82),
+      rgba(206, 214, 232, 0.84),
+      rgba(190, 198, 216, 0.85)
+    );
+  --ticker-border: color-mix(in srgb, rgba(0, 82, 245, 0.35) 45%, rgba(255, 255, 255, 0.65) 55%);
+  --ticker-shadow:
+    0 22px 58px rgba(24, 30, 48, 0.35),
+    0 8px 28px rgba(12, 16, 30, 0.22);
+  --ticker-backdrop-filter: blur(26px) saturate(1.5) brightness(1.05);
+  --ticker-surface-noise: var(--noise-subtle);
+  --ticker-ambient-mask:
+    linear-gradient(120deg,
+      rgba(255, 255, 255, 0.18) 0%,
+      rgba(0, 82, 245, 0.12) 36%,
+      transparent 72%
+    ),
+    radial-gradient(circle at 18% 20%,
+      rgba(255, 255, 255, 0.24) 0%,
+      transparent 60%
+    ),
+    radial-gradient(circle at 80% 78%,
+      rgba(0, 82, 245, 0.16) 0%,
+      transparent 65%
+    );
+  --ticker-ambient-caustics:
+    repeating-linear-gradient(125deg,
+      transparent 0px 22px,
+      rgba(0, 82, 245, 0.08) 22px 28px,
+      transparent 28px 44px
+    ),
+    repeating-linear-gradient(-125deg,
+      transparent 0px 24px,
+      rgba(255, 255, 255, 0.06) 24px 30px,
+      transparent 30px 46px
+    );
+  --ticker-motion-stack:
+    tickerMaterialize 1.2s var(--ease-premium) both,
+    liquidGlassSweep 26s linear infinite,
+    liquidGlassPulse 6s var(--ease-premium) infinite 1.8s;
+  --ticker-label-width: calc(118px * var(--ui-scale));
+  --ticker-label-size: calc(12.5px * var(--ui-scale));
+  --ticker-label-weight: 700;
+  --ticker-label-letter: calc(2px * var(--ui-scale));
+  --ticker-label-color: rgba(34, 34, 68, 0.92);
+  --ticker-label-shadow:
+    0 0 6px rgba(255, 255, 255, 0.42),
+    0 1px 4px rgba(18, 24, 38, 0.32);
+  --ticker-divider-color:
+    linear-gradient(90deg,
+      color-mix(in srgb, rgba(0, 82, 245, 0.55) 60%, rgba(255, 255, 255, 0.45) 40%),
+      rgba(182, 198, 226, 0.6)
+    );
+  --ticker-accent-overlay:
+    radial-gradient(circle at 12% 18%,
+      rgba(255, 255, 255, 0.3) 0%,
+      transparent 55%
+    ),
+    radial-gradient(circle at 76% 68%,
+      rgba(0, 82, 245, 0.22) 0%,
+      transparent 60%
+    ),
+    linear-gradient(140deg,
+      color-mix(in srgb, var(--accent, #0052f5) 45%, rgba(255, 255, 255, 0.3)),
+      color-mix(in srgb, var(--accent, #0052f5) 30%, rgba(34, 34, 68, 0.35))
+    );
+  --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent, #0052f5) 55%, rgba(255, 255, 255, 0.7));
+  --ticker-accent-glow:
+    0 0 20px color-mix(in srgb, var(--accent, #0052f5) 32%, rgba(255, 255, 255, 0.4)),
+    0 0 36px rgba(34, 38, 64, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  --ticker-accent-animation: liquidGlassSweep 22s var(--ease-premium) infinite;
+  --popup-surface-a:
+    linear-gradient(145deg,
+      rgba(255, 255, 255, 0.82),
+      rgba(236, 240, 248, 0.78)
+    );
+  --popup-surface-b:
+    linear-gradient(305deg,
+      rgba(224, 232, 250, 0.76),
+      rgba(206, 214, 234, 0.78)
+    );
+  --popup-border-color: color-mix(in srgb, rgba(0, 82, 245, 0.32) 55%, rgba(255, 255, 255, 0.6) 45%);
+  --popup-shadow:
+    0 26px 54px rgba(28, 32, 52, 0.3),
+    0 10px 24px rgba(12, 16, 30, 0.18);
+  --popup-text-color: rgba(34, 34, 68, 0.92);
+  --popup-divider-color: rgba(148, 168, 214, 0.45);
+  --popup-countdown-color: color-mix(in srgb, rgba(34, 34, 68, 0.85) 65%, var(--accent, #0052f5) 35%);
+  --popup-countdown-dot: color-mix(in srgb, var(--accent, #0052f5) 65%, rgba(255, 255, 255, 0.5) 35%);
+  --popup-accent-strip:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--accent, #0052f5) 60%, rgba(255, 255, 255, 0.45)),
+      color-mix(in srgb, var(--accent, #0052f5) 32%, rgba(34, 34, 68, 0.35))
+    );
+  --popup-sheen:
+    linear-gradient(120deg,
+      rgba(255, 255, 255, 0.35) 0%,
+      rgba(0, 82, 245, 0.2) 42%,
+      transparent 74%
+    );
+  --popup-glow-anim: liquidGlassPulse 14s var(--ease-premium) infinite;
+}
+
 /* NEURAL THEME - AI-inspired organic networks */
 .ticker--neural,
 body.ticker--neural,
@@ -576,6 +690,40 @@ body.ticker--contrast {
 }
 
 /* Motion library */
+@keyframes liquidGlassSweep {
+  0% {
+    background-position: 0% 50%, 0% 0%, 0% 0%;
+    filter: saturate(1) brightness(1);
+  }
+  35% {
+    background-position: 60% 45%, 30% 20%, 80% 40%;
+    filter: saturate(1.08) brightness(1.04);
+  }
+  65% {
+    background-position: 120% 55%, 70% 60%, 150% 85%;
+    filter: saturate(1.12) brightness(1.05);
+  }
+  100% {
+    background-position: 200% 50%, 100% 70%, 220% 110%;
+    filter: saturate(1.02) brightness(1);
+  }
+}
+
+@keyframes liquidGlassPulse {
+  0%, 100% {
+    opacity: 0.72;
+    filter: saturate(1) brightness(1);
+  }
+  40% {
+    opacity: 0.98;
+    filter: saturate(1.18) brightness(1.06);
+  }
+  70% {
+    opacity: 0.86;
+    filter: saturate(1.08) brightness(1.03);
+  }
+}
+
 @keyframes tickerMaterialize {
   0% {
     transform: translate3d(0, 40%, 0) scale(0.96);

--- a/public/index.html
+++ b/public/index.html
@@ -1487,9 +1487,9 @@
     const MAX_SLATE_NOTES = 6;
     const MAX_BRB_LENGTH = 280;
     const MESSAGE_PLACEHOLDER = 'Add a ticker message…';
-      const THEME_OPTIONS = Array.isArray(OVERLAY_THEMES) && OVERLAY_THEMES.length
+    const THEME_OPTIONS = Array.isArray(OVERLAY_THEMES) && OVERLAY_THEMES.length
         ? OVERLAY_THEMES
-        : ['holographic', 'neural', 'quantum', 'crystalline', 'neon-noir'];
+        : ['holographic', 'liquid-glass', 'neural', 'quantum', 'crystalline', 'neon-noir'];
     const THEME_CLASSNAMES = THEME_OPTIONS.map(theme => `ticker--${theme}`);
     const MAX_PRESET_NAME_LENGTH = 80;
     const MAX_SCENE_NAME_LENGTH = 80;

--- a/public/js/shared-utils.js
+++ b/public/js/shared-utils.js
@@ -21,6 +21,7 @@
 
   const OVERLAY_THEMES = [
     'holographic',
+    'liquid-glass',
     'neural',
     'quantum',
     'crystalline',

--- a/public/output.html
+++ b/public/output.html
@@ -677,7 +677,7 @@
     const MAX_SLATE_TEXT_LENGTH = 200;
     const MAX_SLATE_NOTES = 6;
     const HIDE_TRANSITION_FALLBACK_MS = 700;
-    const THEME_CLASSNAMES = (Array.isArray(OVERLAY_THEMES) ? OVERLAY_THEMES : ['holographic', 'neural', 'quantum', 'crystalline', 'neon-noir']).map(theme => `ticker--${theme}`);
+    const THEME_CLASSNAMES = (Array.isArray(OVERLAY_THEMES) ? OVERLAY_THEMES : ['holographic', 'liquid-glass', 'neural', 'quantum', 'crystalline', 'neon-noir']).map(theme => `ticker--${theme}`);
 
     const DEFAULT_OVERLAY = {
       label: 'LIVE',


### PR DESCRIPTION
## Summary
- add a liquid glass inspired theme that wires frosted gradients and motion to ticker, popup, and slate surfaces
- introduce reusable liquid glass animation keyframes for the new theme
- expose the liquid glass option through shared theme lists so the dashboard and overlay can select it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56aff896883219aa87f2509ee2a2c