### PR TITLE
Improve slate controls and highlight handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1342,13 +1342,18 @@
               <div class="control-group">
                 <label for="slateRotation">Rotation Interval (seconds)</label>
                 <div class="segment-row" style="gap: 12px; align-items: center;">
-                  <input type="range" id="slateRotation" min="4" max="60" step="1" value="12" />
-                  <input type="number" id="slateRotationNumber" min="4" max="60" step="1" value="12" style="max-width: 80px;" />
+                  <input type="range" id="slateRotation" min="4" max="900" step="1" value="12" />
+                  <input type="number" id="slateRotationNumber" min="4" max="900" step="1" value="12" style="max-width: 90px;" />
                 </div>
+                <p class="control-hint">Supports gaps of up to 900 seconds (15 minutes).</p>
               </div>
               <div class="control-group">
                 <label for="slateClockLabel">Clock label</label>
                 <input type="text" id="slateClockLabel" maxlength="48" placeholder="UK TIME" />
+              </div>
+              <div class="control-group">
+                <label for="slateClockSubtitle">Clock subtitle</label>
+                <input type="text" id="slateClockSubtitle" maxlength="200" placeholder="UK time" />
               </div>
               <div class="control-group">
                 <label for="slateNextLabel">Next-up label</label>
@@ -1549,6 +1554,7 @@
       rotationSeconds: 12,
       showClock: true,
       clockLabel: 'UK TIME',
+      clockSubtitle: 'UK time',
       nextLabel: 'Next up',
       nextTitle: '',
       nextSubtitle: '',
@@ -1564,7 +1570,10 @@
       ...DEFAULT_SLATE_SOURCE,
       rotationSeconds: typeof clampSlateRotationSeconds === 'function'
         ? clampSlateRotationSeconds(DEFAULT_SLATE_SOURCE.rotationSeconds, 12)
-        : Math.min(Math.max(Math.round(Number(DEFAULT_SLATE_SOURCE.rotationSeconds) || 12), 4), 60),
+        : Math.min(Math.max(Math.round(Number(DEFAULT_SLATE_SOURCE.rotationSeconds) || 12), 4), 900),
+      clockSubtitle: typeof DEFAULT_SLATE_SOURCE.clockSubtitle === 'string'
+        ? DEFAULT_SLATE_SOURCE.clockSubtitle.trim().slice(0, MAX_SLATE_TEXT_LENGTH)
+        : 'UK time',
       notes: typeof normaliseSlateNotes === 'function'
         ? normaliseSlateNotes(DEFAULT_SLATE_SOURCE.notes, MAX_SLATE_NOTES, MAX_SLATE_TEXT_LENGTH)
         : (Array.isArray(DEFAULT_SLATE_SOURCE.notes)
@@ -1675,6 +1684,7 @@
       slateRotation: document.getElementById('slateRotation'),
       slateRotationNumber: document.getElementById('slateRotationNumber'),
       slateClockLabel: document.getElementById('slateClockLabel'),
+      slateClockSubtitle: document.getElementById('slateClockSubtitle'),
       slateNextLabel: document.getElementById('slateNextLabel'),
       slateNextTitle: document.getElementById('slateNextTitle'),
       slateNextSubtitle: document.getElementById('slateNextSubtitle'),
@@ -1857,7 +1867,7 @@
       }
       const numeric = Number(value);
       if (!Number.isFinite(numeric)) return DEFAULT_SLATE.rotationSeconds || 12;
-      return Math.min(Math.max(Math.round(numeric), 4), 60);
+      return Math.min(Math.max(Math.round(numeric), 4), 900);
     }
 
     function computeSlateVisibleSeconds(rotationSeconds) {
@@ -1904,6 +1914,9 @@
       if (Number.isFinite(data.rotationSeconds)) result.rotationSeconds = clampSlateRotation(data.rotationSeconds);
       if (typeof data.showClock === 'boolean') result.showClock = data.showClock;
       if (typeof data.clockLabel === 'string') result.clockLabel = data.clockLabel.trim().slice(0, MAX_SLATE_TITLE_LENGTH);
+      if (typeof data.clockSubtitle === 'string') {
+        result.clockSubtitle = data.clockSubtitle.trim().slice(0, MAX_SLATE_TEXT_LENGTH);
+      }
       if (typeof data.nextLabel === 'string') result.nextLabel = data.nextLabel.trim().slice(0, MAX_SLATE_TITLE_LENGTH);
       if (typeof data.nextTitle === 'string') result.nextTitle = data.nextTitle.trim().slice(0, MAX_SLATE_TITLE_LENGTH);
       if (typeof data.nextSubtitle === 'string') result.nextSubtitle = data.nextSubtitle.trim().slice(0, MAX_SLATE_TEXT_LENGTH);
@@ -1924,6 +1937,7 @@
         rotationSeconds: clampSlateRotation(normalised.rotationSeconds),
         showClock: !!normalised.showClock,
         clockLabel: normalised.clockLabel || '',
+        clockSubtitle: normalised.clockSubtitle || '',
         nextLabel: normalised.nextLabel || '',
         nextTitle: normalised.nextTitle || '',
         nextSubtitle: normalised.nextSubtitle || '',
@@ -1965,7 +1979,7 @@
           type: 'clock',
           pill: (activeSlate.clockLabel || 'UK TIME').trim(),
           title: time,
-          subtitle: 'UK time',
+          subtitle: (activeSlate.clockSubtitle || 'UK time').trim(),
           meta: ''
         });
       }
@@ -2208,6 +2222,7 @@
       if (el.slateRotation) el.slateRotation.value = rotation;
       if (el.slateRotationNumber) el.slateRotationNumber.value = rotation;
       if (el.slateClockLabel) el.slateClockLabel.value = slateState.clockLabel || '';
+      if (el.slateClockSubtitle) el.slateClockSubtitle.value = slateState.clockSubtitle || '';
       if (el.slateNextLabel) el.slateNextLabel.value = slateState.nextLabel || '';
       if (el.slateNextTitle) el.slateNextTitle.value = slateState.nextTitle || '';
       if (el.slateNextSubtitle) el.slateNextSubtitle.value = slateState.nextSubtitle || '';
@@ -2320,14 +2335,18 @@ function normalisePopupData(data) {
         .map(s => s.trim())
         .filter(Boolean);
       const merged = Array.from(new Set([...DEFAULT_HIGHLIGHTS, ...custom]));
-      if (!merged.length) {
+      const tokens = merged
+        .map(entry => entry.trim())
+        .filter(Boolean)
+        .sort((a, b) => b.length - a.length);
+      if (!tokens.length) {
         highlightRegex = null;
         return;
       }
-      const escaped = merged
+      const escaped = tokens
         .map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
         .join('|');
-      highlightRegex = new RegExp(`\\b(${escaped})\\b`, 'gi');
+      highlightRegex = escaped ? new RegExp(`\\b(${escaped})\\b`, 'gi') : null;
     }
 
     function escapeHtml(str) {
@@ -4556,14 +4575,21 @@ function normalisePopupData(data) {
     }
 
     el.highlightWords.addEventListener('input', () => {
-      overlayPrefs.highlight = normaliseHighlightInput(el.highlightWords.value);
+      const raw = el.highlightWords.value;
+      const normalised = normaliseHighlightInput(raw);
+      const changed = overlayPrefs.highlight !== normalised;
+      overlayPrefs.highlight = normalised;
+      if (changed) {
+        updateHighlightRegex();
+        renderMessages();
+        renderPopupControls();
+        updateOverlayChip();
+        saveLocal();
+        queueOverlaySave();
+      }
+    });
+    el.highlightWords.addEventListener('blur', () => {
       el.highlightWords.value = overlayPrefs.highlight;
-      updateHighlightRegex();
-      renderMessages();
-      renderPopupControls();
-      updateOverlayChip();
-      saveLocal();
-      queueOverlaySave();
     });
 
     if (el.slateEnabled) {
@@ -4600,6 +4626,14 @@ function normalisePopupData(data) {
       });
       el.slateClockLabel.addEventListener('blur', () => {
         el.slateClockLabel.value = slateState.clockLabel || '';
+      });
+    }
+    if (el.slateClockSubtitle) {
+      el.slateClockSubtitle.addEventListener('input', () => {
+        updateSlateTextField('clockSubtitle', el.slateClockSubtitle.value, MAX_SLATE_TEXT_LENGTH);
+      });
+      el.slateClockSubtitle.addEventListener('blur', () => {
+        el.slateClockSubtitle.value = slateState.clockSubtitle || '';
       });
     }
     if (el.slateNextLabel) {

--- a/public/js/shared-config.js
+++ b/public/js/shared-config.js
@@ -16,7 +16,7 @@
     'today'
   ]);
 
-  const DEFAULT_HIGHLIGHT_STRING = DEFAULT_HIGHLIGHTS.join(',');
+  const DEFAULT_HIGHLIGHT_STRING = DEFAULT_HIGHLIGHTS.join(', ');
 
   const DEFAULT_OVERLAY = Object.freeze({
     label: 'LIVE',
@@ -44,6 +44,7 @@
     rotationSeconds: 12,
     showClock: true,
     clockLabel: 'UK TIME',
+    clockSubtitle: 'UK time',
     nextLabel: 'Next up',
     nextTitle: '',
     nextSubtitle: '',

--- a/public/js/shared-utils.js
+++ b/public/js/shared-utils.js
@@ -55,7 +55,7 @@
   }
 
   function clampSlateRotationSeconds(value, fallback) {
-    return clampNumber(value, 4, 60, fallback, 0);
+    return clampNumber(value, 4, 900, fallback, 0);
   }
 
   function normaliseHighlightList(value) {
@@ -63,7 +63,7 @@
       .split(',')
       .map(part => part.trim())
       .filter(Boolean)
-      .join(',');
+      .join(', ');
   }
 
   function normalisePosition(value) {

--- a/public/output.html
+++ b/public/output.html
@@ -418,18 +418,18 @@
 
     .slate {
       position: fixed;
-      top: calc(16px * var(--ui-scale) / 1.75);
-      right: calc(16px * var(--ui-scale) / 1.75);
-      max-width: min(calc(220px * var(--ui-scale)), 24vw);
+      top: calc(24px * var(--ui-scale) / 1.75);
+      right: calc(24px * var(--ui-scale) / 1.75);
+      max-width: min(calc(360px * var(--ui-scale) / 1.75), 32vw);
       pointer-events: none;
       opacity: 0;
-      transform: translate3d(8px, -8px, 0);
+      transform: translate3d(calc(16px * var(--ui-scale) / 1.75), calc(-16px * var(--ui-scale) / 1.75), 0);
       transition: opacity 0.32s ease, transform 0.32s cubic-bezier(0.22, 0.61, 0.36, 1);
       z-index: 1080;
     }
 
     .slate.push-down {
-      top: calc(var(--bar-height) + (24px * var(--ui-scale) / 1.75) + (10px * var(--popup-scale)));
+      top: calc(var(--bar-height) + (28px * var(--ui-scale) / 1.75) + (12px * var(--popup-scale)));
     }
 
     .slate.show {
@@ -441,11 +441,11 @@
       position: relative;
       display: flex;
       flex-direction: column;
-      gap: calc(6px * var(--ui-scale) / 1.75);
-      padding: calc(12px * var(--ui-scale) / 1.75) calc(16px * var(--ui-scale) / 1.75);
-      padding-left: calc(18px * var(--ui-scale) / 1.75);
-      min-width: min(calc(180px * var(--ui-scale) / 1.75), 24vw);
-      max-width: min(calc(220px * var(--ui-scale) / 1.75), 24vw);
+      gap: calc(8px * var(--ui-scale) / 1.75);
+      padding: calc(16px * var(--ui-scale) / 1.75) calc(22px * var(--ui-scale) / 1.75);
+      padding-left: calc(22px * var(--ui-scale) / 1.75);
+      min-width: min(calc(240px * var(--ui-scale) / 1.75), 30vw);
+      max-width: min(calc(320px * var(--ui-scale) / 1.75), 32vw);
       border: 1px solid var(--popup-border-color);
       border-radius: 0;
       background: linear-gradient(150deg, var(--popup-surface-a), var(--popup-surface-b));
@@ -711,6 +711,7 @@
       rotationSeconds: 12,
       showClock: true,
       clockLabel: 'UK TIME',
+      clockSubtitle: 'UK time',
       nextLabel: 'Next up',
       nextTitle: '',
       nextSubtitle: '',
@@ -726,7 +727,10 @@
       ...DEFAULT_SLATE_SOURCE,
       rotationSeconds: typeof clampSlateRotationSeconds === 'function'
         ? clampSlateRotationSeconds(DEFAULT_SLATE_SOURCE.rotationSeconds, 12)
-        : Math.min(Math.max(Math.round(Number(DEFAULT_SLATE_SOURCE.rotationSeconds) || 12), 4), 60),
+        : Math.min(Math.max(Math.round(Number(DEFAULT_SLATE_SOURCE.rotationSeconds) || 12), 4), 900),
+      clockSubtitle: typeof DEFAULT_SLATE_SOURCE.clockSubtitle === 'string'
+        ? DEFAULT_SLATE_SOURCE.clockSubtitle.trim().slice(0, 200)
+        : 'UK time',
       notes: typeof normaliseSlateNotes === 'function'
         ? normaliseSlateNotes(DEFAULT_SLATE_SOURCE.notes, 6, 200)
         : (Array.isArray(DEFAULT_SLATE_SOURCE.notes)
@@ -739,7 +743,13 @@
     };
 
     function normaliseHighlightString(value) {
-      return normaliseHighlightList ? normaliseHighlightList(value) : String(value || '').split(',').map(part => part.trim()).filter(Boolean).join(',');
+      return normaliseHighlightList
+        ? normaliseHighlightList(value)
+        : String(value || '')
+            .split(',')
+            .map(part => part.trim())
+            .filter(Boolean)
+            .join(', ');
     }
 
     function clampScale(value) {
@@ -1035,7 +1045,7 @@
       }
       const numeric = Number(value);
       if (!Number.isFinite(numeric)) return DEFAULT_SLATE.rotationSeconds || 12;
-      return Math.min(Math.max(Math.round(numeric), 4), 60);
+      return Math.min(Math.max(Math.round(numeric), 4), 900);
     }
 
     function computeSlateVisibleSeconds(rotationSeconds) {
@@ -1085,6 +1095,9 @@
       if (Number.isFinite(data.rotationSeconds)) result.rotationSeconds = clampSlateRotation(data.rotationSeconds);
       if (typeof data.showClock === 'boolean') result.showClock = data.showClock;
       if (typeof data.clockLabel === 'string') result.clockLabel = data.clockLabel.trim().slice(0, MAX_SLATE_TITLE_LENGTH);
+      if (typeof data.clockSubtitle === 'string') {
+        result.clockSubtitle = data.clockSubtitle.trim().slice(0, MAX_SLATE_TEXT_LENGTH);
+      }
       if (typeof data.nextLabel === 'string') result.nextLabel = data.nextLabel.trim().slice(0, MAX_SLATE_TITLE_LENGTH);
       if (typeof data.nextTitle === 'string') result.nextTitle = data.nextTitle.trim().slice(0, MAX_SLATE_TITLE_LENGTH);
       if (typeof data.nextSubtitle === 'string') result.nextSubtitle = data.nextSubtitle.trim().slice(0, MAX_SLATE_TEXT_LENGTH);
@@ -1130,7 +1143,7 @@
           type: 'clock',
           pill: (activeSlate.clockLabel || 'UK TIME').trim(),
           title: time,
-          subtitle: 'UK time',
+          subtitle: (activeSlate.clockSubtitle || 'UK time').trim(),
           meta: ''
         });
       }
@@ -1479,7 +1492,12 @@
           if (trimmed) merged.add(trimmed.toLowerCase());
         }
         if (!merged.size) return null;
-        const escaped = Array.from(merged)
+        const tokens = Array.from(merged)
+          .map(word => word.trim())
+          .filter(Boolean)
+          .sort((a, b) => b.length - a.length);
+        if (!tokens.length) return null;
+        const escaped = tokens
           .map(word => word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
           .join('|');
         return escaped ? new RegExp(`\\b(${escaped})\\b`, 'gi') : null;
@@ -1488,7 +1506,9 @@
       setCustomHighlights(list) {
         const normalised = normaliseHighlightString(list);
         this.overlay.highlight = normalised;
-        this.customHighlights = normalised ? normalised.split(',') : [];
+        this.customHighlights = normalised
+          ? normalised.split(',').map(part => part.trim())
+          : [];
         this.highlightRegex = this.buildHighlightRegex();
         this.cachedLongestMessageWidth = null;
         if (this.popupVisible && this.popup.text) {
@@ -1676,7 +1696,7 @@
       if (this.slateSubtitleNode) {
         const subtitle = card.subtitle && typeof card.subtitle === 'string'
           ? card.subtitle
-          : 'UK time';
+          : (DEFAULT_SLATE.clockSubtitle || 'UK time');
         if (subtitle) {
           this.slateSubtitleNode.textContent = subtitle;
           this.slateSubtitleNode.classList.remove('is-hidden');

--- a/server.js
+++ b/server.js
@@ -97,6 +97,7 @@ const BASE_DEFAULT_SLATE_SOURCE = CONFIG_DEFAULT_SLATE
       rotationSeconds: 12,
       showClock: true,
       clockLabel: 'UK TIME',
+      clockSubtitle: 'UK time',
       nextLabel: 'Next up',
       nextTitle: '',
       nextSubtitle: '',
@@ -761,6 +762,10 @@ function sanitiseSlateInput(input, options = {}) {
 
   if (typeof input.clockLabel === 'string') {
     result.clockLabel = input.clockLabel.trim().slice(0, MAX_SLATE_TITLE_LENGTH);
+  }
+
+  if (typeof input.clockSubtitle === 'string') {
+    result.clockSubtitle = input.clockSubtitle.trim().slice(0, MAX_SLATE_TEXT_LENGTH);
   }
 
   if (typeof input.nextLabel === 'string') {

--- a/tests/shared-utils.test.js
+++ b/tests/shared-utils.test.js
@@ -51,7 +51,8 @@ test('isSafeCssColor rejects malformed or unsafe input', () => {
 });
 
 test('normaliseHighlightList trims whitespace and drops empty entries', () => {
-  assert.equal(normaliseHighlightList(' one, two , ,three '), 'one,two,three');
-  assert.equal(normaliseHighlightList(['alpha', ' beta ', ' '].join(',')), 'alpha,beta');
+  assert.equal(normaliseHighlightList(' one, two , ,three '), 'one, two, three');
+  assert.equal(normaliseHighlightList(['alpha', ' beta ', ' '].join(',')), 'alpha, beta');
+  assert.equal(normaliseHighlightList('Silent Hill f'), 'Silent Hill f', 'internal spaces are preserved');
   assert.equal(normaliseHighlightList(null), '', 'null input normalises to empty string');
 });

--- a/ticker-state.json
+++ b/ticker-state.json
@@ -21,7 +21,7 @@
   "overlay": {
     "label": "LIVE",
     "accent": "#ef4444",
-    "highlight": "live,breaking,alert,update,disclaimer,silent,hill",
+    "highlight": "live, breaking, alert, update, disclaimer, silent, hill",
     "scale": 1.75,
     "popupScale": 1.3,
     "position": "bottom",
@@ -44,6 +44,7 @@
     "rotationSeconds": 60,
     "showClock": true,
     "clockLabel": "Local Time",
+    "clockSubtitle": "UK time",
     "nextLabel": "Next up",
     "nextTitle": "",
     "nextSubtitle": "",


### PR DESCRIPTION
## Summary
- allow the segment slate to rotate for up to 15 minutes, add a clock subtitle field, and persist the new data on the server
- refine highlight editing to keep user spacing, prioritise longer phrases, and format defaults with comma-and-space separation
- realign the overlay slate widget styling with the popup and update shared defaults, fixtures, and tests accordingly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56aa737f08321967a156589c55903