### PR TITLE
Apply monotone dark theme and add monotone overlay option

### DIFF
--- a/public/css/themes.css
+++ b/public/css/themes.css
@@ -51,6 +51,73 @@
   --ticker-backdrop-filter: blur(20px) saturate(1.2);
 }
 
+/* MONOTONE THEME - Minimalist graphite surfaces */
+.ticker--monotone,
+body.ticker--monotone {
+  --ticker-surface-a:
+    linear-gradient(165deg,
+      rgba(20, 22, 30, 0.94),
+      rgba(12, 14, 20, 0.96)
+    );
+  --ticker-surface-b:
+    linear-gradient(200deg,
+      rgba(10, 12, 18, 0.94),
+      rgba(6, 7, 12, 0.96)
+    );
+  --ticker-border: rgba(255, 255, 255, 0.08);
+  --ticker-shadow:
+    0 18px 46px rgba(0, 0, 0, 0.55),
+    0 4px 20px rgba(0, 0, 0, 0.45);
+  --ticker-label-width: calc(120px * var(--ui-scale));
+  --ticker-label-size: calc(12px * var(--ui-scale));
+  --ticker-label-weight: 700;
+  --ticker-label-letter: calc(1.8px * var(--ui-scale));
+  --ticker-label-color: rgba(244, 246, 252, 0.98);
+  --ticker-label-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.6);
+  --ticker-divider-color: rgba(255, 255, 255, 0.14);
+  --ticker-surface-noise: var(--noise-subtle);
+  --ticker-ambient-mask:
+    linear-gradient(180deg,
+      rgba(255, 255, 255, 0.04),
+      rgba(0, 0, 0, 0) 60%
+    );
+  --ticker-accent-overlay:
+    linear-gradient(160deg,
+      color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.1)),
+      color-mix(in srgb, var(--accent) 20%, rgba(8, 10, 16, 0.92))
+    );
+  --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.25));
+  --ticker-accent-glow:
+    0 0 18px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.18));
+  --ticker-accent-animation: tickerAmbientGlow 18s var(--ease-smooth) infinite;
+  --ticker-backdrop-filter: blur(22px) saturate(1.05);
+  --ticker-depth-filter: saturate(1.02) brightness(1.02);
+  --popup-surface-a:
+    linear-gradient(180deg,
+      rgba(18, 20, 28, 0.94),
+      rgba(10, 12, 18, 0.94)
+    );
+  --popup-surface-b:
+    linear-gradient(200deg,
+      rgba(8, 10, 16, 0.92),
+      rgba(6, 7, 12, 0.94)
+    );
+  --popup-border-color: rgba(255, 255, 255, 0.1);
+  --popup-shadow:
+    0 18px 44px rgba(0, 0, 0, 0.5),
+    0 6px 18px rgba(0, 0, 0, 0.35);
+  --popup-text-color: rgba(244, 246, 252, 0.96);
+  --popup-divider-color: rgba(255, 255, 255, 0.12);
+  --popup-countdown-color: color-mix(in srgb, rgba(240, 242, 248, 0.92) 70%, var(--accent) 30%);
+  --popup-countdown-dot: color-mix(in srgb, rgba(250, 252, 255, 0.55) 60%, var(--accent) 40%);
+  --popup-accent-strip:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--accent) 68%, rgba(255, 255, 255, 0.1)),
+      color-mix(in srgb, var(--accent) 24%, rgba(6, 7, 12, 0.92))
+    );
+}
+
 /* HOLOGRAPHIC THEME - Futuristic iridescent surfaces */
 .ticker--holographic,
 body.ticker--holographic,

--- a/public/index.html
+++ b/public/index.html
@@ -12,33 +12,33 @@
   <style>
     :root {
       --ui-scale: 1;
-      --bg: #04060e;
-      --bg-accent: #080b17;
-      --panel: rgba(10, 13, 22, 0.88);
-      --panel-border: rgba(76, 92, 142, 0.35);
-      --panel-highlight: rgba(124, 92, 255, 0.28);
-      --muted: rgba(22, 26, 40, 0.92);
-      --text: #f5f7ff;
-      --subtle: #9da6c4;
+      --bg: #050608;
+      --bg-accent: #090b10;
+      --panel: rgba(12, 14, 20, 0.9);
+      --panel-border: rgba(110, 116, 134, 0.28);
+      --panel-highlight: color-mix(in srgb, var(--accent) 22%, rgba(255, 255, 255, 0.08));
+      --muted: rgba(18, 20, 28, 0.92);
+      --text: #f5f7fb;
+      --subtle: #9ea3b4;
       --accent: #7c5cff;
-      --accent-strong: #8a7fff;
-      --accent-soft: rgba(124, 92, 255, 0.16);
-      --accent-bright: color-mix(in srgb, var(--accent) 82%, white 18%);
-      --accent-glow: color-mix(in srgb, var(--accent) 60%, rgba(255, 255, 255, 0.5));
-      --accent-duo: color-mix(in srgb, var(--accent) 65%, #5aa8ff 35%);
-      --accent-contrast: color-mix(in srgb, var(--accent) 58%, #45e6c3 42%);
+      --accent-strong: color-mix(in srgb, var(--accent) 78%, white 22%);
+      --accent-soft: color-mix(in srgb, var(--accent) 12%, transparent);
+      --accent-bright: color-mix(in srgb, var(--accent) 82%, #f8f9ff 18%);
+      --accent-glow: color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.42));
+      --accent-duo: color-mix(in srgb, var(--accent) 60%, #1b1d27 40%);
+      --accent-contrast: color-mix(in srgb, var(--accent) 58%, #0e1018 42%);
       --success: #3ddc97;
       --danger: #ff6b6b;
       --danger-soft: rgba(255, 107, 107, 0.18);
       --radius: 16px;
-      --shadow: 0 18px 40px rgba(5, 8, 22, 0.48);
-      --shadow-soft: 0 12px 28px rgba(5, 8, 22, 0.38);
-      --pill-bg: rgba(34, 40, 60, 0.78);
-      --input-bg: rgba(14, 18, 28, 0.9);
-      --input-border: rgba(102, 119, 163, 0.26);
-      --chip-bg: rgba(54, 62, 92, 0.52);
-      --chip-border: rgba(116, 132, 188, 0.32);
-      --toast-bg: rgba(18, 22, 34, 0.94);
+      --shadow: 0 18px 40px rgba(4, 5, 12, 0.55);
+      --shadow-soft: 0 12px 28px rgba(4, 6, 16, 0.4);
+      --pill-bg: rgba(30, 32, 42, 0.78);
+      --input-bg: rgba(14, 16, 24, 0.92);
+      --input-border: rgba(110, 116, 134, 0.22);
+      --chip-bg: rgba(36, 38, 48, 0.7);
+      --chip-border: rgba(120, 124, 140, 0.26);
+      --toast-bg: rgba(16, 18, 24, 0.95);
       --popup-scale: 1;
     }
 
@@ -50,9 +50,9 @@
       margin: 0;
       font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
       background:
-        radial-gradient(1200px 760px at -10% -20%, rgba(132, 96, 255, 0.16), transparent 70%),
-        radial-gradient(980px 620px at 120% -10%, rgba(47, 103, 255, 0.14), transparent 65%),
-        linear-gradient(160deg, #050711 0%, #080d19 55%, #02030a 100%);
+        radial-gradient(1200px 720px at -10% -20%, color-mix(in srgb, var(--accent) 8%, rgba(20, 22, 28, 0.85)), transparent 68%),
+        radial-gradient(980px 620px at 120% -10%, rgba(24, 26, 34, 0.8), transparent 60%),
+        linear-gradient(160deg, #050608 0%, #080a11 55%, #020305 100%);
       color: var(--text);
       -webkit-font-smoothing: antialiased;
       padding: 44px 24px 64px;
@@ -138,7 +138,7 @@
 
     .panel--accent {
       --panel-bg: rgba(16, 20, 36, 0.9);
-      --panel-border-color: color-mix(in srgb, var(--accent) 36%, rgba(118, 134, 189, 0.45));
+      --panel-border-color: color-mix(in srgb, var(--accent) 36%, rgba(112, 118, 136, 0.45));
       --panel-glow: color-mix(in srgb, var(--accent) 24%, rgba(124, 92, 255, 0.22));
       --panel-sheen: rgba(255, 255, 255, 0.06);
       box-shadow: 0 24px 60px rgba(8, 12, 30, 0.5);
@@ -146,8 +146,8 @@
 
     .panel--neutral {
       --panel-bg: rgba(13, 16, 26, 0.9);
-      --panel-border-color: rgba(118, 134, 189, 0.26);
-      --panel-glow: rgba(118, 134, 189, 0.14);
+      --panel-border-color: rgba(112, 118, 136, 0.26);
+      --panel-glow: rgba(112, 118, 136, 0.14);
       --panel-sheen: rgba(255, 255, 255, 0.04);
     }
 
@@ -296,7 +296,7 @@
       height: 6px;
       border-radius: 999px;
       background: rgba(84, 96, 138, 0.45);
-      border: 1px solid rgba(118, 134, 189, 0.4);
+      border: 1px solid rgba(112, 118, 136, 0.4);
       outline: none;
     }
     input[type="range"]::-webkit-slider-thumb {
@@ -317,7 +317,7 @@
     .segment-row { display: flex; flex-wrap: wrap; gap: 8px; }
     .segment-button {
       appearance: none;
-      border: 1px solid rgba(118, 134, 189, 0.4);
+      border: 1px solid rgba(112, 118, 136, 0.4);
       border-radius: 999px;
       padding: 7px 14px;
       font-size: 12px;
@@ -365,7 +365,7 @@
     .btn:active { transform: translateY(1px); }
     .btn-secondary { background: rgba(54, 62, 92, 0.9); color: #f3f4ff; box-shadow: none; }
     .btn-secondary:hover { box-shadow: 0 12px 26px rgba(32, 38, 60, 0.4); }
-    .btn-ghost { background: rgba(255, 255, 255, 0.04); color: var(--subtle); box-shadow: none; border: 1px dashed rgba(118, 134, 189, 0.35); }
+    .btn-ghost { background: rgba(255, 255, 255, 0.04); color: var(--subtle); box-shadow: none; border: 1px dashed rgba(112, 118, 136, 0.35); }
     .btn-ghost:hover { filter: none; transform: none; border-color: var(--accent); color: #fff; }
     .btn-danger { background: linear-gradient(135deg, var(--danger), #ff856b); box-shadow: 0 14px 26px rgba(255, 107, 107, 0.32); }
     .btn-success { background: linear-gradient(135deg, var(--success), #23c485); color: #04160f; box-shadow: 0 14px 26px rgba(61, 220, 151, 0.32); }
@@ -460,7 +460,7 @@
       gap: calc(var(--space-sm) * var(--popup-scale));
       padding: calc(var(--space-md) * var(--popup-scale)) calc(var(--space-lg) * var(--popup-scale));
       border-radius: 0;
-      border: 1px solid var(--popup-border-color, rgba(118, 134, 189, 0.28));
+      border: 1px solid var(--popup-border-color, rgba(112, 118, 136, 0.28));
       background:
         var(--ticker-ambient-mask, transparent),
         linear-gradient(150deg, var(--popup-surface-a, rgba(28, 30, 44, 0.95)), var(--popup-surface-b, rgba(12, 14, 24, 0.9)));
@@ -484,14 +484,14 @@
       animation: var(--popup-glow-anim, none);
       --preview-accent: #ef4444;
       --accent: var(--preview-accent);
-      --accent-bright: color-mix(in srgb, var(--accent) 82%, white 18%);
-      --accent-glow: color-mix(in srgb, var(--accent) 60%, rgba(255, 255, 255, 0.45));
-      --accent-duo: color-mix(in srgb, var(--accent) 68%, #5aa8ff 32%);
-      --accent-contrast: color-mix(in srgb, var(--accent) 58%, #45e6c3 42%);
-      --ticker-surface-a: rgba(18, 20, 28, 0.92);
-      --ticker-surface-b: rgba(8, 10, 16, 0.9);
-      --ticker-border: rgba(118, 134, 189, 0.28);
-      --ticker-shadow: 0 14px 38px rgba(5, 8, 22, 0.42);
+      --accent-bright: color-mix(in srgb, var(--accent) 80%, #f8f9ff 20%);
+      --accent-glow: color-mix(in srgb, var(--accent) 56%, rgba(255, 255, 255, 0.4));
+      --accent-duo: color-mix(in srgb, var(--accent) 60%, #1c1e27 40%);
+      --accent-contrast: color-mix(in srgb, var(--accent) 56%, #0d0f16 44%);
+      --ticker-surface-a: rgba(16, 18, 26, 0.94);
+      --ticker-surface-b: rgba(6, 8, 14, 0.92);
+      --ticker-border: rgba(120, 126, 146, 0.24);
+      --ticker-shadow: 0 14px 38px rgba(4, 6, 16, 0.45);
       --ticker-divider-color: rgba(255, 255, 255, 0.16);
       --popup-surface-a: color-mix(in srgb, var(--ticker-surface-a) 92%, rgba(255, 255, 255, 0.02));
       --popup-surface-b: color-mix(in srgb, var(--ticker-surface-b) 92%, rgba(0, 0, 0, 0.08));
@@ -558,7 +558,7 @@
     .message-list {
       display: flex;
       flex-direction: column;
-      border: 1px solid rgba(118, 134, 189, 0.25);
+      border: 1px solid rgba(112, 118, 136, 0.25);
       border-radius: 14px;
       overflow: hidden;
       background: rgba(10, 14, 24, 0.85);
@@ -569,7 +569,7 @@
       gap: 14px;
       align-items: center;
       padding: 14px 16px;
-      border-bottom: 1px solid rgba(118, 134, 189, 0.18);
+      border-bottom: 1px solid rgba(112, 118, 136, 0.18);
     }
     .message-item:last-child { border-bottom: none; }
     .message-preview { font-size: 15px; line-height: 1.4; color: #e7ebff; }
@@ -597,7 +597,7 @@
       min-height: 72px;
       resize: vertical;
       border-radius: 10px;
-      border: 1px solid rgba(118, 134, 189, 0.35);
+      border: 1px solid rgba(112, 118, 136, 0.35);
       background: rgba(14, 18, 28, 0.92);
       color: #f5f7ff;
       font-size: 14px;
@@ -617,7 +617,7 @@
       color: #8df0c6;
     }
     .message-actions button[data-action="cancel"] {
-      background: rgba(118, 134, 189, 0.22);
+      background: rgba(112, 118, 136, 0.22);
       color: #d5ddff;
     }
 
@@ -627,7 +627,7 @@
       display: flex;
       flex-direction: column;
       gap: 14px;
-      border: 1px solid rgba(118, 134, 189, 0.22);
+      border: 1px solid rgba(112, 118, 136, 0.22);
       border-radius: 16px;
       padding: 18px;
       background: rgba(12, 16, 28, 0.72);
@@ -646,8 +646,8 @@
       position: relative;
       border-radius: 14px;
       overflow: hidden;
-      border: 1px solid rgba(118, 134, 189, 0.26);
-      background: radial-gradient(120% 120% at 50% 0%, color-mix(in srgb, var(--accent) 18%, rgba(42, 52, 96, 0.55)), rgba(10, 12, 20, 0.9));
+      border: 1px solid rgba(112, 118, 136, 0.26);
+      background: radial-gradient(120% 120% at 50% 0%, color-mix(in srgb, var(--accent) 18%, rgba(26, 28, 36, 0.6)), rgba(10, 12, 20, 0.9));
       aspect-ratio: 16 / 9;
       min-height: 220px;
     }
@@ -664,7 +664,7 @@
     .preset-header input { max-width: 240px; }
     .preset-list { display: flex; flex-direction: column; gap: 12px; }
     .preset-card {
-      border: 1px solid rgba(118, 134, 189, 0.25);
+      border: 1px solid rgba(112, 118, 136, 0.25);
       border-radius: 12px;
       padding: 16px;
       background: rgba(18, 22, 34, 0.82);
@@ -736,7 +736,7 @@
       gap: 12px;
       padding: 18px;
       border-radius: 14px;
-      border: 1px solid rgba(118, 134, 189, 0.32);
+      border: 1px solid rgba(112, 118, 136, 0.32);
       background: rgba(20, 26, 44, 0.85);
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 18px 38px rgba(5, 7, 16, 0.45);
     }
@@ -762,7 +762,7 @@
       left: 24px;
       bottom: 24px;
       background: var(--toast-bg);
-      border: 1px solid rgba(118, 134, 189, 0.35);
+      border: 1px solid rgba(112, 118, 136, 0.35);
       color: #fff;
       padding: 12px 16px;
       border-radius: 12px;
@@ -1295,6 +1295,7 @@
                 <button type="button" class="segment-button" data-theme="quantum">Quantum</button>
                 <button type="button" class="segment-button" data-theme="crystalline">Crystalline</button>
                 <button type="button" class="segment-button" data-theme="neon-noir">Neon Noir</button>
+                <button type="button" class="segment-button" data-theme="monotone">Monotone</button>
               </div>
               <div class="theme-notes">
                 <span><strong>Holographic</strong> iridescent refraction with caustic light</span>
@@ -1302,6 +1303,7 @@
                 <span><strong>Quantum</strong> particle gradients and energetic beams</span>
                 <span><strong>Crystalline</strong> precision glass facets and cool sheen</span>
                 <span><strong>Neon Noir</strong> cyberpunk neon with deep contrast</span>
+                <span><strong>Monotone</strong> graphite minimalism with accent highlights</span>
               </div>
           </div>
           <div class="toggle-row">
@@ -1494,7 +1496,7 @@
     const MESSAGE_PLACEHOLDER = 'Add a ticker message…';
     const THEME_OPTIONS = Array.isArray(OVERLAY_THEMES) && OVERLAY_THEMES.length
         ? OVERLAY_THEMES
-        : ['holographic', 'liquid-glass', 'neural', 'quantum', 'crystalline', 'neon-noir'];
+        : ['holographic', 'liquid-glass', 'neural', 'quantum', 'crystalline', 'neon-noir', 'monotone'];
     const THEME_CLASSNAMES = THEME_OPTIONS.map(theme => `ticker--${theme}`);
     const MAX_PRESET_NAME_LENGTH = 80;
     const MAX_SCENE_NAME_LENGTH = 80;
@@ -1517,7 +1519,7 @@
       mode: 'auto',
       accentAnim: true,
       sparkle: true,
-        theme: 'holographic',
+      theme: 'monotone',
         ...(sharedConfig.DEFAULT_OVERLAY || {})
       };
     if (!DEFAULT_OVERLAY.highlight) {

--- a/public/js/shared-config.js
+++ b/public/js/shared-config.js
@@ -28,7 +28,7 @@
     mode: 'auto',
     accentAnim: true,
     sparkle: true,
-    theme: 'holographic'
+    theme: 'monotone'
   });
 
   const DEFAULT_POPUP = Object.freeze({

--- a/public/js/shared-utils.js
+++ b/public/js/shared-utils.js
@@ -25,7 +25,8 @@
     'neural',
     'quantum',
     'crystalline',
-    'neon-noir'
+    'neon-noir',
+    'monotone'
   ];
 
   function clampNumber(value, min, max, fallback, precision) {

--- a/public/output.html
+++ b/public/output.html
@@ -19,18 +19,18 @@
       --padding-x: var(--space-lg);
       --divider-height: calc(var(--space-sm) * 1.75);
       --accent: #ef4444;
-      --accent-bright: color-mix(in srgb, var(--accent) 82%, white 18%);
-      --accent-soft: color-mix(in srgb, var(--accent) 40%, transparent);
-      --accent-glow: color-mix(in srgb, var(--accent) 62%, rgba(255, 255, 255, 0.45));
-      --accent-muted: color-mix(in srgb, var(--accent) 55%, rgba(10, 12, 20, 0.7));
-      --accent-duo: color-mix(in srgb, var(--accent) 68%, #5aa8ff 32%);
-      --accent-contrast: color-mix(in srgb, var(--accent) 58%, #45e6c3 42%);
-      --surface-a: rgba(18, 20, 28, 0.92);
-      --surface-b: rgba(8, 10, 16, 0.9);
+      --accent-bright: color-mix(in srgb, var(--accent) 80%, #f8f9ff 20%);
+      --accent-soft: color-mix(in srgb, var(--accent) 16%, transparent);
+      --accent-glow: color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.4));
+      --accent-muted: color-mix(in srgb, var(--accent) 55%, rgba(14, 16, 24, 0.7));
+      --accent-duo: color-mix(in srgb, var(--accent) 60%, #1c1e27 40%);
+      --accent-contrast: color-mix(in srgb, var(--accent) 56%, #0d0f16 44%);
+      --surface-a: rgba(14, 16, 24, 0.94);
+      --surface-b: rgba(6, 8, 14, 0.92);
       --surface-border: rgba(255, 255, 255, 0.12);
       --surface-outline: rgba(255, 255, 255, 0.06);
-      --text: #fefefe;
-      --shadow: 0 18px 52px rgba(3, 5, 14, 0.5);
+      --text: #f5f7fb;
+      --shadow: 0 18px 52px rgba(3, 5, 14, 0.52);
       --marquee-pps: 110;
       --hide-shift: calc(12px * var(--ui-scale) / 1.75);
       --ticker-surface-a: var(--surface-a);
@@ -46,10 +46,10 @@
       --ticker-label-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
       --ticker-divider-color: rgba(255, 255, 255, 0.32);
       --ticker-accent-overlay:
-        linear-gradient(155deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 62%),
+        linear-gradient(155deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0) 62%),
         linear-gradient(150deg, var(--accent-bright), var(--accent-muted));
-      --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.35));
-      --ticker-accent-glow: 0 0 12px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.25));
+      --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.3));
+      --ticker-accent-glow: 0 0 12px color-mix(in srgb, var(--accent) 24%, rgba(255, 255, 255, 0.22));
       --ticker-accent-animation: holographicShift 20s var(--ease-premium) infinite;
       --popup-surface-a: color-mix(in srgb, var(--ticker-surface-a) 92%, rgba(255, 255, 255, 0.02));
       --popup-surface-b: color-mix(in srgb, var(--ticker-surface-b) 92%, rgba(0, 0, 0, 0.08));
@@ -677,7 +677,7 @@
     const MAX_SLATE_TEXT_LENGTH = 200;
     const MAX_SLATE_NOTES = 6;
     const HIDE_TRANSITION_FALLBACK_MS = 700;
-    const THEME_CLASSNAMES = (Array.isArray(OVERLAY_THEMES) ? OVERLAY_THEMES : ['holographic', 'liquid-glass', 'neural', 'quantum', 'crystalline', 'neon-noir']).map(theme => `ticker--${theme}`);
+    const THEME_CLASSNAMES = (Array.isArray(OVERLAY_THEMES) ? OVERLAY_THEMES : ['holographic', 'liquid-glass', 'neural', 'quantum', 'crystalline', 'neon-noir', 'monotone']).map(theme => `ticker--${theme}`);
 
     const DEFAULT_OVERLAY = {
       label: 'LIVE',
@@ -689,7 +689,7 @@
       mode: 'auto',
       accentAnim: true,
       sparkle: true,
-      theme: 'holographic',
+      theme: 'monotone',
       ...(sharedConfig.DEFAULT_OVERLAY || {})
     };
     if (!DEFAULT_OVERLAY.highlight) {

--- a/server.js
+++ b/server.js
@@ -77,7 +77,7 @@ const BASE_DEFAULT_OVERLAY = CONFIG_DEFAULT_OVERLAY
       mode: 'auto',
       accentAnim: true,
       sparkle: true,
-      theme: 'holographic'
+      theme: 'monotone'
     };
 
 const BASE_DEFAULT_POPUP = CONFIG_DEFAULT_POPUP


### PR DESCRIPTION
## Summary
- restyle the dashboard with a monotone dark palette that leans on the user accent colour for highlights
- add a graphite-inspired monotone overlay theme, expose it in the dashboard theme picker, and make it the default option
- update shared defaults and server configuration so the new monotone treatment is used consistently

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5719128048321b6787ef6bf10273c