### PR TITLE
Remove ticker bar position animation

### DIFF
--- a/public/css/themes.css
+++ b/public/css/themes.css
@@ -726,17 +726,14 @@ body.ticker--contrast {
 
 @keyframes tickerMaterialize {
   0% {
-    transform: translate3d(0, 40%, 0) scale(0.96);
     opacity: 0;
     filter: blur(6px) saturate(0.8);
   }
   60% {
-    transform: translate3d(0, -5%, 0) scale(1.02);
     opacity: 1;
     filter: blur(0px) saturate(1.08);
   }
   100% {
-    transform: translate3d(0, 0, 0) scale(1);
     opacity: 1;
     filter: none;
   }


### PR DESCRIPTION
## Summary
- remove the transform and scale steps from the ticker entrance animation so the bar stays fixed once shown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d57270c1f48321b52fd0a9e7f78531