### PR TITLE
Preserve scene overlay configuration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1469,6 +1469,7 @@
 
   <script src="js/shared-config.js"></script>
   <script src="js/shared-utils.js"></script>
+  <script src="js/scene-normaliser.js"></script>
   <script>
     const {
       OVERLAY_THEMES,
@@ -1500,6 +1501,26 @@
     const THEME_CLASSNAMES = THEME_OPTIONS.map(theme => `ticker--${theme}`);
     const MAX_PRESET_NAME_LENGTH = 80;
     const MAX_SCENE_NAME_LENGTH = 80;
+
+    const ScenesModule = window.TickerScenes || {};
+    const normaliseSceneEntryImpl = typeof ScenesModule.normaliseSceneEntry === 'function'
+      ? ScenesModule.normaliseSceneEntry
+      : null;
+    const serialiseOverlayForSceneImpl = typeof ScenesModule.serialiseOverlayForScene === 'function'
+      ? ScenesModule.serialiseOverlayForScene
+      : null;
+    const SCENE_OVERLAY_KEYS = [
+      'label',
+      'accent',
+      'highlight',
+      'scale',
+      'popupScale',
+      'position',
+      'mode',
+      'accentAnim',
+      'sparkle',
+      'theme'
+    ];
 
     const sharedConfig = window.SharedConfig || {};
     const DEFAULT_HIGHLIGHTS = Array.isArray(sharedConfig.DEFAULT_HIGHLIGHTS) && sharedConfig.DEFAULT_HIGHLIGHTS.length
@@ -3272,61 +3293,54 @@ function normalisePopupData(data) {
       renderPresets();
     }
 
-    function normaliseSceneEntry(entry) {
-      if (!entry || typeof entry !== 'object') return null;
-      const name = String(entry.name || '').trim().slice(0, MAX_SCENE_NAME_LENGTH);
-      if (!name) return null;
-
-      const tickerSource = (entry.ticker && typeof entry.ticker === 'object') ? entry.ticker : entry;
-      const tickerMessages = sanitiseMessages(tickerSource.messages || entry.messages || []);
-      const displayDuration = clampDuration(tickerSource.displayDuration ?? state.displayDuration);
-      const intervalRaw = tickerSource.intervalBetween ?? entry.intervalBetween;
-      const intervalSeconds = typeof clampIntervalSeconds === 'function'
-        ? clampIntervalSeconds(intervalRaw, minutesToSeconds(state.intervalMinutes))
-        : Math.max(0, Math.min(3600, Math.round(Number(intervalRaw) || 0)));
-      const ticker = {
-        messages: tickerMessages,
-        displayDuration,
-        intervalBetween: intervalSeconds,
-        isActive: !!(tickerSource.isActive ?? entry.isActive) && tickerMessages.length > 0
-      };
-
-      const popup = normalisePopupData(entry.popup || {});
-
-      let slate = null;
-      if (entry.slate && typeof entry.slate === 'object') {
-        const normalisedSlate = normaliseSlateData(entry.slate);
-        slate = {
-          isEnabled: !!normalisedSlate.isEnabled,
-          rotationSeconds: clampSlateRotation(normalisedSlate.rotationSeconds),
-          showClock: !!normalisedSlate.showClock,
-          clockLabel: normalisedSlate.clockLabel || '',
-          nextLabel: normalisedSlate.nextLabel || '',
-          nextTitle: normalisedSlate.nextTitle || '',
-          nextSubtitle: normalisedSlate.nextSubtitle || '',
-          sponsorLabel: normalisedSlate.sponsorLabel || '',
-          sponsorName: normalisedSlate.sponsorName || '',
-          sponsorTagline: normalisedSlate.sponsorTagline || '',
-          notesLabel: normalisedSlate.notesLabel || '',
-          notes: Array.isArray(normalisedSlate.notes) ? normalisedSlate.notes.slice(0, MAX_SLATE_NOTES) : []
-        };
+    function buildSceneOverlayPayload(source) {
+      if (!source || typeof source !== 'object') return null;
+      if (serialiseOverlayForSceneImpl) {
+        const overlay = serialiseOverlayForSceneImpl(source, {
+          normaliseOverlayData,
+          overlayKeys: SCENE_OVERLAY_KEYS,
+          includeEmptyStrings: true
+        });
+        if (overlay && Object.keys(overlay).length) {
+          return overlay;
+        }
+        return null;
       }
-
-      let overlay = null;
-      const rawTheme = entry.overlay && typeof entry.overlay === 'object' ? entry.overlay.theme : null;
-      if (typeof rawTheme === 'string') {
-        const normalisedTheme = typeof sharedNormaliseTheme === 'function'
-          ? sharedNormaliseTheme(rawTheme)
-          : rawTheme.trim().toLowerCase();
-        if (normalisedTheme && THEME_OPTIONS.includes(normalisedTheme)) {
-          overlay = { theme: normalisedTheme };
+      const fallback = {
+        theme: source.theme,
+        position: source.position,
+        mode: source.mode,
+        accentAnim: source.accentAnim,
+        sparkle: source.sparkle
+      };
+      for (const key of Object.keys(fallback)) {
+        if (fallback[key] === undefined || fallback[key] === null || fallback[key] === '') {
+          delete fallback[key];
         }
       }
+      return Object.keys(fallback).length ? fallback : null;
+    }
 
-      const id = String(entry.id || generateClientId('scene'));
-      const updatedAt = Number(entry.updatedAt) || Date.now();
-
-      return { id, name, ticker, popup, overlay, slate, updatedAt };
+    function normaliseSceneEntry(entry) {
+      if (!normaliseSceneEntryImpl) return null;
+      return normaliseSceneEntryImpl(entry, {
+        maxNameLength: MAX_SCENE_NAME_LENGTH,
+        sanitiseMessages,
+        clampDuration,
+        clampIntervalSeconds,
+        minutesToSeconds,
+        getDisplayDuration: () => state.displayDuration,
+        getIntervalMinutes: () => state.intervalMinutes,
+        normalisePopupData,
+        normaliseSlateData,
+        clampSlateRotation,
+        maxSlateNotes: MAX_SLATE_NOTES,
+        generateId: () => generateClientId('scene'),
+        normaliseOverlayData,
+        overlayKeys: SCENE_OVERLAY_KEYS,
+        includeEmptyStrings: true,
+        now: () => Date.now()
+      });
     }
 
     function applyScenesData(list) {
@@ -4298,6 +4312,7 @@ function normalisePopupData(data) {
         if (tickerResult.truncated) notes.push(`skipped ${tickerResult.truncated}`);
         if (notes.length) toast(`Scene adjusted • ${notes.join('; ')}`);
       }
+      const overlay = buildSceneOverlayPayload(overlayPrefs);
       const payload = {
         id: existingId || generateClientId('scene'),
         name: trimmedName,
@@ -4315,26 +4330,15 @@ function normalisePopupData(data) {
           countdownTarget: popup.countdownTarget
         },
         slate: serialiseSlateState(),
-        overlay: {
-          theme: overlayPrefs.theme,
-          position: overlayPrefs.position,
-          mode: overlayPrefs.mode,
-          accentAnim: overlayPrefs.accentAnim,
-          sparkle: overlayPrefs.sparkle
-        },
         updatedAt: Date.now()
       };
-      if (!payload.overlay.theme) {
-        delete payload.overlay.theme;
-      }
-      if (!payload.overlay.position) {
-        delete payload.overlay.position;
-      }
-      if (!payload.overlay.mode) {
-        delete payload.overlay.mode;
-      }
-      if (!Object.keys(payload.overlay).length) {
-        delete payload.overlay;
+      if (overlay && Object.keys(overlay).length) {
+        if (!overlay.theme) delete overlay.theme;
+        if (!overlay.position) delete overlay.position;
+        if (!overlay.mode) delete overlay.mode;
+        if (Object.keys(overlay).length) {
+          payload.overlay = overlay;
+        }
       }
       return payload;
     }

--- a/public/js/scene-normaliser.js
+++ b/public/js/scene-normaliser.js
@@ -1,0 +1,168 @@
+(function (root, factory) {
+  const exports = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = exports;
+  }
+  if (root && typeof root === 'object') {
+    root.TickerScenes = exports;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this, function () {
+  const DEFAULT_OVERLAY_KEYS = [
+    'label',
+    'accent',
+    'highlight',
+    'scale',
+    'popupScale',
+    'position',
+    'mode',
+    'accentAnim',
+    'sparkle',
+    'theme'
+  ];
+
+  function serialiseOverlayForScene(rawOverlay, options = {}) {
+    if (!rawOverlay || typeof rawOverlay !== 'object') return null;
+
+    const normaliseOverlayData = options.normaliseOverlayData;
+    const allowedKeys = Array.isArray(options.overlayKeys) && options.overlayKeys.length
+      ? options.overlayKeys
+      : DEFAULT_OVERLAY_KEYS;
+    const includeEmptyStrings = options.includeEmptyStrings !== false;
+
+    const normalised = typeof normaliseOverlayData === 'function'
+      ? normaliseOverlayData(rawOverlay)
+      : { ...rawOverlay };
+
+    const result = {};
+    for (const key of allowedKeys) {
+      if (!Object.prototype.hasOwnProperty.call(rawOverlay, key)) continue;
+      if (!(key in normalised)) continue;
+      const value = normalised[key];
+      if (typeof value === 'string') {
+        const stringValue = String(value);
+        if (!includeEmptyStrings) {
+          const trimmed = stringValue.trim();
+          if (!trimmed) continue;
+          result[key] = trimmed;
+        } else {
+          result[key] = stringValue;
+        }
+      } else if (value !== undefined) {
+        result[key] = value;
+      }
+    }
+
+    if (!Object.keys(result).length && Object.prototype.hasOwnProperty.call(rawOverlay, 'theme')) {
+      const themeSource = typeof normaliseOverlayData === 'function'
+        ? normaliseOverlayData({ theme: rawOverlay.theme })
+        : { theme: rawOverlay.theme };
+      if (themeSource && typeof themeSource.theme === 'string' && themeSource.theme) {
+        result.theme = themeSource.theme;
+      }
+    }
+
+    return Object.keys(result).length ? result : null;
+  }
+
+  function normaliseSceneEntry(entry, options = {}) {
+    if (!entry || typeof entry !== 'object') return null;
+
+    const maxNameLength = typeof options.maxNameLength === 'number' ? options.maxNameLength : 80;
+    const getDisplayDuration = typeof options.getDisplayDuration === 'function'
+      ? options.getDisplayDuration
+      : () => options.displayDurationFallback ?? 5;
+    const getIntervalMinutes = typeof options.getIntervalMinutes === 'function'
+      ? options.getIntervalMinutes
+      : () => options.intervalMinutesFallback ?? 0;
+    const clampDuration = options.clampDuration;
+    const clampIntervalSeconds = options.clampIntervalSeconds;
+    const minutesToSeconds = typeof options.minutesToSeconds === 'function'
+      ? options.minutesToSeconds
+      : (value => Math.max(0, Math.min(3600, Math.round(Number(value || 0) * 60))));
+    const sanitiseMessages = typeof options.sanitiseMessages === 'function'
+      ? options.sanitiseMessages
+      : (list => (Array.isArray(list) ? list.map(item => String(item || '').trim()).filter(Boolean) : []));
+    const normalisePopupData = typeof options.normalisePopupData === 'function'
+      ? options.normalisePopupData
+      : (() => ({}));
+    const normaliseSlateData = typeof options.normaliseSlateData === 'function'
+      ? options.normaliseSlateData
+      : (() => ({}));
+    const clampSlateRotation = typeof options.clampSlateRotation === 'function'
+      ? options.clampSlateRotation
+      : (value => value);
+    const maxSlateNotes = typeof options.maxSlateNotes === 'number' ? options.maxSlateNotes : 6;
+    const generateId = typeof options.generateId === 'function'
+      ? options.generateId
+      : (() => 'scene');
+    const now = typeof options.now === 'function' ? options.now : () => Date.now();
+
+    const name = String(entry.name || '').trim().slice(0, maxNameLength);
+    if (!name) return null;
+
+    const tickerSource = (entry.ticker && typeof entry.ticker === 'object') ? entry.ticker : entry;
+    const tickerMessages = sanitiseMessages(tickerSource.messages ?? entry.messages ?? []);
+
+    const displayDurationInput = tickerSource.displayDuration ?? entry.displayDuration ?? getDisplayDuration();
+    const displayDuration = typeof clampDuration === 'function'
+      ? clampDuration(displayDurationInput)
+      : (Number(displayDurationInput) || getDisplayDuration());
+
+    const intervalRaw = tickerSource.intervalBetween ?? entry.intervalBetween;
+    const fallbackIntervalSeconds = minutesToSeconds(getIntervalMinutes());
+    const intervalSeconds = typeof clampIntervalSeconds === 'function'
+      ? clampIntervalSeconds(intervalRaw, fallbackIntervalSeconds)
+      : Math.max(0, Math.min(3600, Math.round(Number(intervalRaw ?? fallbackIntervalSeconds) || 0)));
+
+    const ticker = {
+      messages: tickerMessages,
+      displayDuration,
+      intervalBetween: intervalSeconds,
+      isActive: !!(tickerSource.isActive ?? entry.isActive) && tickerMessages.length > 0
+    };
+
+    const popup = normalisePopupData(entry.popup || {});
+
+    let slate = null;
+    if (entry.slate && typeof entry.slate === 'object') {
+      const normalisedSlate = normaliseSlateData(entry.slate);
+      slate = {
+        isEnabled: !!normalisedSlate.isEnabled,
+        rotationSeconds: clampSlateRotation(normalisedSlate.rotationSeconds),
+        showClock: !!normalisedSlate.showClock,
+        clockLabel: normalisedSlate.clockLabel || '',
+        nextLabel: normalisedSlate.nextLabel || '',
+        nextTitle: normalisedSlate.nextTitle || '',
+        nextSubtitle: normalisedSlate.nextSubtitle || '',
+        sponsorLabel: normalisedSlate.sponsorLabel || '',
+        sponsorName: normalisedSlate.sponsorName || '',
+        sponsorTagline: normalisedSlate.sponsorTagline || '',
+        notesLabel: normalisedSlate.notesLabel || '',
+        notes: Array.isArray(normalisedSlate.notes)
+          ? normalisedSlate.notes.slice(0, maxSlateNotes)
+          : []
+      };
+    }
+
+    const overlay = serialiseOverlayForScene(entry.overlay, options);
+
+    const id = String(entry.id || generateId());
+    const updatedAtRaw = Number(entry.updatedAt ?? entry._updatedAt);
+    const updatedAt = Number.isFinite(updatedAtRaw) ? updatedAtRaw : now();
+
+    return {
+      id,
+      name,
+      ticker,
+      popup,
+      overlay,
+      slate,
+      updatedAt
+    };
+  }
+
+  return {
+    serialiseOverlayForScene,
+    normaliseSceneEntry
+  };
+});

--- a/tests/scene-normaliser.test.js
+++ b/tests/scene-normaliser.test.js
@@ -1,0 +1,143 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  normaliseSceneEntry,
+  serialiseOverlayForScene
+} = require('../public/js/scene-normaliser.js');
+
+const OVERLAY_KEYS = [
+  'label',
+  'accent',
+  'highlight',
+  'scale',
+  'popupScale',
+  'position',
+  'mode',
+  'accentAnim',
+  'sparkle',
+  'theme'
+];
+
+const BASE_OVERLAY = {
+  label: 'LIVE',
+  accent: '#ef4444',
+  highlight: 'live,alert',
+  scale: 1.75,
+  popupScale: 1,
+  position: 'bottom',
+  mode: 'auto',
+  accentAnim: true,
+  sparkle: true,
+  theme: 'monotone'
+};
+
+function stubNormaliseOverlayData(data = {}) {
+  const result = { ...BASE_OVERLAY };
+  for (const key of OVERLAY_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(data, key)) continue;
+    const value = data[key];
+    if (typeof value === 'string') {
+      result[key] = value.trim();
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+const sceneOptions = {
+  maxNameLength: 80,
+  sanitiseMessages: list => Array.isArray(list) ? list.map(item => String(item || '').trim()).filter(Boolean) : [],
+  clampDuration: value => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return 5;
+    return Math.min(Math.max(Math.round(numeric), 2), 90);
+  },
+  clampIntervalSeconds: (value, fallback) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return fallback;
+    return Math.max(0, Math.min(3600, Math.round(numeric)));
+  },
+  minutesToSeconds: minutes => {
+    const numeric = Number(minutes);
+    if (!Number.isFinite(numeric)) return 0;
+    return Math.max(0, Math.min(3600, Math.round(numeric * 60)));
+  },
+  getDisplayDuration: () => 5,
+  getIntervalMinutes: () => 0,
+  normalisePopupData: popup => ({
+    text: typeof popup.text === 'string' ? popup.text : '',
+    isActive: !!popup.isActive,
+    durationSeconds: popup.durationSeconds ?? null,
+    countdownEnabled: !!popup.countdownEnabled,
+    countdownTarget: popup.countdownTarget ?? null
+  }),
+  normaliseSlateData: slate => ({
+    ...slate,
+    notes: Array.isArray(slate?.notes) ? slate.notes.slice() : []
+  }),
+  clampSlateRotation: value => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return 12;
+    return Math.min(Math.max(Math.round(numeric), 4), 900);
+  },
+  maxSlateNotes: 6,
+  generateId: () => 'generated-scene',
+  normaliseOverlayData: stubNormaliseOverlayData,
+  overlayKeys: OVERLAY_KEYS,
+  includeEmptyStrings: true,
+  now: () => 1234
+};
+
+test('overlay fields survive scene round trip', () => {
+  const overlayPrefs = {
+    label: ' ALERT ',
+    accent: ' #123123 ',
+    highlight: ' focus,alert ',
+    scale: 1.2,
+    popupScale: 0.9,
+    position: 'top',
+    mode: 'chunk',
+    accentAnim: false,
+    sparkle: false,
+    theme: 'neural'
+  };
+
+  const overlayPayload = serialiseOverlayForScene(overlayPrefs, {
+    normaliseOverlayData: stubNormaliseOverlayData,
+    overlayKeys: OVERLAY_KEYS,
+    includeEmptyStrings: true
+  });
+
+  assert.ok(overlayPayload, 'overlay payload should be created');
+
+  const builtScene = {
+    id: 'scene-1',
+    name: 'Overlay test',
+    ticker: {
+      messages: ['hello'],
+      displayDuration: 5,
+      intervalBetween: 30,
+      isActive: true
+    },
+    popup: {
+      text: 'popup',
+      isActive: true,
+      durationSeconds: 10,
+      countdownEnabled: false,
+      countdownTarget: null
+    },
+    overlay: overlayPayload,
+    updatedAt: 5000
+  };
+
+  const persistedScene = JSON.parse(JSON.stringify(builtScene));
+  const reloadedScene = normaliseSceneEntry(persistedScene, sceneOptions);
+
+  assert.deepEqual(
+    reloadedScene.overlay,
+    overlayPayload,
+    'overlay configuration should round trip without losing fields'
+  );
+});


### PR DESCRIPTION
## Summary
- factor scene normalisation and overlay serialisation helpers into a shared module and wire them into the dashboard
- keep full overlay configuration when saving and loading scenes so persisted payloads match what the overlay expects
- add a node:test regression that exercises the normalise → persist → reload round trip for overlay data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e06317e483218122bcf2206b6dc8