### PR TITLE
Add state import/export endpoints and UI controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ With the server running on <http://127.0.0.1:3000>:
 
 The dashboard consumes the SSE stream to stay in sync with the server, and the overlay hydrates itself from the same `/ticker/stream` endpoint when it loads. OBS can point directly at the overlay URL, while operators can manage queues and presets from the dashboard.
 
+## Importing and exporting state
+
+Use the dashboard controls in the header to export the complete ticker state to a JSON download or import a previously saved file. The buttons call the `/ticker/state/export` and `/ticker/state/import` endpoints under the hood and trigger a full dashboard refresh so every panel is rehydrated after a successful import.
+
 ## Configuration
 
 Set the following environment variables before starting `server.js` to change where assets and state are loaded from (see [Getting Started](#getting-started) for the launch command):

--- a/public/index.html
+++ b/public/index.html
@@ -192,6 +192,17 @@
       gap: 14px;
     }
 
+    .status-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 12px;
+    }
+
+    .status-actions .btn {
+      min-width: 140px;
+    }
+
     .status-card {
       display: flex;
       flex-direction: column;
@@ -1160,6 +1171,12 @@
           <div class="status-item"><label><input type="checkbox" id="autoStart" /> Auto-start when messages exist</label></div>
         </div>
       </div>
+
+      <div class="status-actions">
+        <button type="button" class="btn btn-ghost" id="exportState">Export state</button>
+        <button type="button" class="btn btn-ghost" id="importState">Import state</button>
+        <input type="file" id="importStateInput" accept="application/json,.json" hidden />
+      </div>
     </div>
 
     <div class="layout-grid">
@@ -1628,6 +1645,9 @@
       overlayChip: document.getElementById('overlayUrlChip'),
       overlayText: document.getElementById('overlayUrlText'),
       serverUrl: document.getElementById('serverUrl'),
+      stateExport: document.getElementById('exportState'),
+      stateImport: document.getElementById('importState'),
+      stateImportInput: document.getElementById('importStateInput'),
       statusServer: document.getElementById('statusServer'),
       statusActive: document.getElementById('statusActive'),
       statusActiveText: document.getElementById('statusActiveText'),
@@ -4468,6 +4488,79 @@ function normalisePopupData(data) {
       connectStream();
       fetchState({ silent: true });
       updateOverlayChip();
+    });
+
+    el.stateExport.addEventListener('click', async () => {
+      if (!confirm('Export the full dashboard state as a JSON download?')) {
+        return;
+      }
+      const base = serverBase();
+      try {
+        const res = await fetch(`${base}/ticker/state/export`, { cache: 'no-store' });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'ticker-state.json';
+        a.click();
+        setTimeout(() => URL.revokeObjectURL(url), 500);
+        toast('State exported');
+      } catch (err) {
+        console.error('State export failed', err);
+        toast('Failed to export state');
+      }
+    });
+
+    el.stateImport.addEventListener('click', () => {
+      if (!el.stateImportInput) return;
+      el.stateImportInput.value = '';
+      el.stateImportInput.click();
+    });
+
+    el.stateImportInput.addEventListener('change', async () => {
+      const file = el.stateImportInput.files && el.stateImportInput.files[0];
+      if (!file) return;
+      if (!confirm(`Import "${file.name}" and replace the current dashboard state?`)) {
+        el.stateImportInput.value = '';
+        return;
+      }
+      try {
+        const text = await file.text();
+        let parsed;
+        try {
+          parsed = JSON.parse(text);
+        } catch (err) {
+          throw new Error('Selected file is not valid JSON');
+        }
+        const base = serverBase();
+        const res = await fetch(`${base}/ticker/state/import`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(parsed)
+        });
+        let data = null;
+        try {
+          data = await res.json();
+        } catch (err) {
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}`);
+          }
+        }
+        if (!res.ok || !data || data.ok !== true) {
+          const message = data?.error || data?.message || `Import failed (HTTP ${res.status})`;
+          throw new Error(message);
+        }
+        await fetchState({ silent: false });
+        toast('State imported');
+      } catch (err) {
+        console.error('State import failed', err);
+        toast(err.message || 'Failed to import state');
+      } finally {
+        el.stateImportInput.value = '';
+      }
     });
 
     el.autoStart.addEventListener('change', () => {

--- a/tests/state-roundtrip.test.js
+++ b/tests/state-roundtrip.test.js
@@ -1,0 +1,261 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const { once } = require('node:events');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const { setTimeout: delay } = require('node:timers/promises');
+
+const ROOT_DIR = path.join(__dirname, '..');
+const BASE_URL = 'http://127.0.0.1:3000';
+
+async function waitForServer() {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const res = await fetch(`${BASE_URL}/health`, { cache: 'no-store' });
+      if (res.ok) return;
+    } catch (err) {
+      // ignore until the server is ready
+    }
+    await delay(100);
+  }
+  throw new Error('Server did not become ready in time');
+}
+
+async function gracefulShutdown(child) {
+  if (!child) return;
+  child.kill();
+  try {
+    await once(child, 'exit');
+  } catch (err) {
+    // ignore errors closing the child process
+  }
+}
+
+async function fetchJson(url, options) {
+  const res = await fetch(url, options);
+  let data = null;
+  try {
+    data = await res.json();
+  } catch (err) {
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+  }
+  if (!res.ok) {
+    const message = data && (data.error || data.message);
+    throw new Error(message || `HTTP ${res.status}`);
+  }
+  return data;
+}
+
+test('ticker state export/import round-trips through the API', async t => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ticker-state-'));
+  const stateFile = path.join(tempDir, 'state.json');
+
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: ROOT_DIR,
+    env: {
+      ...process.env,
+      TICKER_STATE_FILE: stateFile
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', () => {});
+  child.stderr.on('data', () => {});
+
+  t.after(async () => {
+    await gracefulShutdown(child);
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  await waitForServer();
+
+  const tickerPayload = {
+    isActive: true,
+    messages: ['Alpha', 'Beta', 'Gamma'],
+    displayDuration: 12,
+    intervalBetween: 180
+  };
+  await fetchJson(`${BASE_URL}/ticker/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(tickerPayload)
+  });
+
+  await fetchJson(`${BASE_URL}/popup/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      text: 'Breaking update',
+      isActive: true,
+      durationSeconds: 25,
+      countdownEnabled: false
+    })
+  });
+
+  await fetchJson(`${BASE_URL}/ticker/overlay`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      label: 'LIVE',
+      accent: '#ff00ff',
+      highlight: 'alpha,beta',
+      scale: 1.2,
+      popupScale: 1.05,
+      position: 'top',
+      mode: 'chunk',
+      accentAnim: false,
+      sparkle: false,
+      theme: 'neural'
+    })
+  });
+
+  await fetchJson(`${BASE_URL}/slate/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      isEnabled: true,
+      rotationSeconds: 30,
+      showClock: false,
+      clockLabel: 'UTC',
+      nextTitle: 'Next Guest',
+      sponsorName: 'Void Corp',
+      notes: ['Bring lower thirds', 'Roll highlights']
+    })
+  });
+
+  await fetchJson(`${BASE_URL}/brb/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      isActive: true,
+      text: 'Back soon'
+    })
+  });
+
+  await fetchJson(`${BASE_URL}/ticker/presets`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      presets: [
+        {
+          id: 'preset-1',
+          name: 'Evening rundown',
+          messages: ['Segment A', 'Segment B'],
+          updatedAt: Date.now()
+        }
+      ]
+    })
+  });
+
+  await fetchJson(`${BASE_URL}/ticker/scenes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      scenes: [
+        {
+          id: 'scene-1',
+          name: 'Prime time',
+          ticker: {
+            messages: ['Scene ticker message'],
+            isActive: true,
+            displayDuration: 10,
+            intervalBetween: 90
+          },
+          popup: {
+            text: 'Scene popup',
+            isActive: true,
+            durationSeconds: 15
+          },
+          overlay: {
+            theme: 'monotone'
+          },
+          slate: {
+            notes: ['Scene note one']
+          },
+          updatedAt: Date.now()
+        }
+      ]
+    })
+  });
+
+  const exportResponse = await fetch(`${BASE_URL}/ticker/state/export`, { cache: 'no-store' });
+  assert.ok(exportResponse.ok, 'export endpoint should respond with 200');
+  const exportedState = await exportResponse.json();
+  assert.ok(exportedState && typeof exportedState === 'object', 'export should return JSON');
+
+  // Mutate the state so the import has to overwrite everything
+  await fetchJson(`${BASE_URL}/ticker/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      isActive: false,
+      messages: ['Zeta'],
+      displayDuration: 4,
+      intervalBetween: 30
+    })
+  });
+  await fetchJson(`${BASE_URL}/popup/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: '', isActive: false })
+  });
+  await fetchJson(`${BASE_URL}/ticker/overlay`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ label: 'ALT', accent: '#00ff00' })
+  });
+  await fetchJson(`${BASE_URL}/slate/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ notes: [] })
+  });
+  await fetchJson(`${BASE_URL}/brb/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ isActive: false, text: 'Changed' })
+  });
+  await fetchJson(`${BASE_URL}/ticker/presets`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ presets: [] })
+  });
+  await fetchJson(`${BASE_URL}/ticker/scenes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ scenes: [] })
+  });
+
+  const importResponse = await fetchJson(`${BASE_URL}/ticker/state/import`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(exportedState)
+  });
+  assert.equal(importResponse.ok, true, 'import endpoint should return ok true');
+
+  const tickerState = await fetchJson(`${BASE_URL}/ticker/state`);
+  assert.deepEqual(tickerState, exportedState.ticker, 'ticker state should match exported payload');
+
+  const popupState = await fetchJson(`${BASE_URL}/popup/state`);
+  assert.deepEqual(popupState, exportedState.popup, 'popup state should match exported payload');
+
+  const overlayState = await fetchJson(`${BASE_URL}/ticker/overlay`);
+  assert.deepEqual(overlayState, exportedState.overlay, 'overlay state should match exported payload');
+
+  const slateState = await fetchJson(`${BASE_URL}/slate/state`);
+  assert.deepEqual(slateState, exportedState.slate, 'slate state should match exported payload');
+
+  const brbState = await fetchJson(`${BASE_URL}/brb/state`);
+  assert.deepEqual(brbState, exportedState.brb, 'brb state should match exported payload');
+
+  const presetState = await fetchJson(`${BASE_URL}/ticker/presets`);
+  assert.deepEqual(presetState.presets, exportedState.presets, 'presets should match exported payload');
+
+  const sceneState = await fetchJson(`${BASE_URL}/ticker/scenes`);
+  assert.deepEqual(sceneState.scenes, exportedState.scenes, 'scenes should match exported payload');
+});


### PR DESCRIPTION
## Summary
- add `/ticker/state/export` and `/ticker/state/import` endpoints that reuse the existing sanitisation and persistence utilities
- surface export/import controls in the dashboard header with confirmation prompts and automatic refresh after successful imports
- cover the round-trip workflow with a node:test suite and mention the dashboard controls in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e19683408321b1a0f4414ca65e27