### PR TITLE
Add next-gen dark themes with dual accent support

### DIFF
--- a/public/css/themes.css
+++ b/public/css/themes.css
@@ -1,19 +1,14 @@
-/* Ultra-Modern Professional Ticker Themes */
+/* Next-generation overlay themes */
 
 :root {
-  /* Advanced easing curves for premium motion */
+  /* Advanced easing for fluid motion */
   --ease-premium: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-elastic: cubic-bezier(0.68, -0.6, 0.32, 1.6);
   --ease-expo: cubic-bezier(0.87, 0, 0.13, 1);
   --ease-circ: cubic-bezier(0.85, 0, 0.15, 1);
   --ease-back: cubic-bezier(0.34, 1.56, 0.64, 1);
 
-  /* Legacy aliases retained for existing stylesheets */
-  --ease-smooth: var(--ease-premium);
-  --ease-bounce: var(--ease-elastic);
-  --ease-dramatic: var(--ease-expo);
-
-  /* Spacing system */
+  /* Spacing scale */
   --space-xs: calc(4px * var(--ui-scale));
   --space-sm: calc(8px * var(--ui-scale));
   --space-md: calc(16px * var(--ui-scale));
@@ -27,871 +22,307 @@
   --text-lg: calc(16px * var(--ui-scale));
   --text-xl: calc(20px * var(--ui-scale));
 
-  /* Core motion orchestration */
-  --ticker-entrance: tickerMaterialize 1.2s var(--ease-premium) both;
+  /* Animation stack */
+  --ticker-entrance: tickerMaterialize 1.1s var(--ease-premium) both;
   --ticker-text-scramble: textScramble 0.8s var(--ease-expo) both;
-  --ticker-ambient: ambientFlow 20s linear infinite;
+  --ticker-ambient: ambientFlow 18s linear infinite;
   --ticker-motion-stack: var(--ticker-entrance), var(--ticker-ambient);
 
-  /* Advanced material effects */
-  --surface-glass-dark: rgba(8, 12, 24, 0.85);
+  /* Shared surface treatments */
+  --surface-glass-dark: rgba(10, 14, 24, 0.85);
   --surface-glass-light: rgba(255, 255, 255, 0.12);
   --surface-metal: linear-gradient(145deg, rgba(40, 44, 52, 0.95), rgba(16, 18, 22, 0.98));
   --surface-carbon:
     repeating-linear-gradient(45deg, transparent, transparent 1px, rgba(255, 255, 255, 0.03) 1px, rgba(255, 255, 255, 0.03) 2px),
     rgba(12, 14, 18, 0.96);
 
-  /* Noise textures */
+  /* Procedural noise textures */
   --noise-subtle: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="200" height="200"%3E%3Cfilter id="n"%3E%3CfeTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4"/%3E%3CfeColorMatrix type="saturate" values="0"/%3E%3C/filter%3E%3Crect width="100%25" height="100%25" filter="url(%23n)" opacity="0.08"/%3E%3C/svg%3E');
   --noise-grain: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="100" height="100"%3E%3Cfilter id="g"%3E%3CfeTurbulence type="turbulence" baseFrequency="0.75" numOctaves="2"/%3E%3CfeColorMatrix type="saturate" values="0"/%3E%3C/filter%3E%3Crect width="100%25" height="100%25" filter="url(%23g)" opacity="0.12"/%3E%3C/svg%3E');
 
-  /* Default depth treatment */
+  /* Depth defaults */
   --ticker-depth-filter: saturate(1.05) brightness(1.04);
   --ticker-depth-mask: none;
   --ticker-backdrop-filter: blur(20px) saturate(1.2);
 }
 
-/* MONOTONE THEME - Minimalist graphite surfaces */
-.ticker--monotone,
-body.ticker--monotone {
-  --accent: #d1d5db;
-  --ticker-surface-a:
-    linear-gradient(165deg,
-      rgba(20, 22, 30, 0.94),
-      rgba(12, 14, 20, 0.96)
-    );
-  --ticker-surface-b:
-    linear-gradient(200deg,
-      rgba(10, 12, 18, 0.94),
-      rgba(6, 7, 12, 0.96)
-    );
-  --ticker-border: rgba(255, 255, 255, 0.08);
+/* Midnight Glass — frosted midnight panes with illuminated particles */
+.ticker--midnight-glass,
+body.ticker--midnight-glass {
+  --ticker-surface-a: rgba(12, 18, 30, 0.88);
+  --ticker-surface-b: rgba(6, 10, 20, 0.94);
+  --ticker-border: color-mix(in srgb, rgba(255, 255, 255, 0.6) 20%, rgba(16, 20, 32, 0.85));
   --ticker-shadow:
-    0 18px 46px rgba(0, 0, 0, 0.55),
-    0 4px 20px rgba(0, 0, 0, 0.45);
+    0 28px 60px rgba(3, 6, 16, 0.55),
+    0 12px 32px rgba(3, 6, 16, 0.36);
+  --ticker-surface-noise: var(--noise-subtle);
+  --ticker-ambient-mask:
+    radial-gradient(circle at 18% 32%, color-mix(in srgb, var(--accent) 34%, transparent) 0%, transparent 72%),
+    radial-gradient(circle at 78% 68%, color-mix(in srgb, var(--accent-secondary, var(--accent)) 42%, transparent) 0%, transparent 76%);
+  --ticker-ambient-opacity: 0.34;
+  --ticker-ambient-blur: 18px;
+  --ticker-accent-overlay:
+    linear-gradient(165deg,
+      color-mix(in srgb, var(--accent-bright) 85%, rgba(255, 255, 255, 0.16)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 54%, rgba(4, 8, 20, 0.74))
+    );
+  --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 46%, rgba(255, 255, 255, 0.3));
+  --ticker-accent-glow: 0 0 26px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.26));
+  --ticker-accent-animation: midnightGlassSweep 20s var(--ease-premium) infinite;
+  --ticker-backdrop-filter: blur(28px) saturate(1.35);
+  --ticker-depth-filter: saturate(1.08) brightness(1.03);
+  --ticker-label-width: calc(112px * var(--ui-scale));
+  --ticker-label-size: calc(13px * var(--ui-scale));
+  --ticker-label-weight: 800;
+  --ticker-label-letter: calc(2.2px * var(--ui-scale));
+  --ticker-label-color: rgba(240, 246, 255, 0.98);
+  --ticker-label-shadow: 0 3px 12px rgba(2, 4, 10, 0.68);
+  --ticker-divider-color: rgba(255, 255, 255, 0.18);
+  --popup-surface-a: rgba(16, 20, 32, 0.94);
+  --popup-surface-b: rgba(8, 12, 24, 0.92);
+  --popup-border-color: rgba(122, 140, 188, 0.34);
+  --popup-shadow: 0 20px 52px rgba(6, 10, 24, 0.55);
+  --popup-text-color: rgba(236, 244, 255, 0.98);
+  --popup-divider-color: rgba(255, 255, 255, 0.18);
+  --popup-countdown-color: color-mix(in srgb, rgba(240, 244, 255, 0.9) 78%, var(--accent) 22%);
+  --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.56) 60%, var(--accent-secondary, var(--accent)) 40%);
+  --popup-accent-strip:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--accent) 78%, rgba(255, 255, 255, 0.18)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 48%, rgba(8, 10, 22, 0.74))
+    );
+}
+
+body.ticker--midnight-glass .highlight,
+.ticker--midnight-glass .highlight {
+  color: color-mix(in srgb, var(--accent-secondary, var(--accent)) 68%, rgba(255, 255, 255, 0.25));
+}
+
+/* Aurora Night — luminous aurora ribbons over deep space */
+.ticker--aurora-night,
+body.ticker--aurora-night {
+  --ticker-surface-a: rgba(4, 8, 18, 0.92);
+  --ticker-surface-b: rgba(2, 6, 14, 0.98);
+  --ticker-border: color-mix(in srgb, rgba(0, 230, 255, 0.45) 55%, rgba(6, 10, 20, 0.85));
+  --ticker-shadow:
+    0 22px 58px rgba(0, 12, 32, 0.58),
+    0 6px 26px rgba(0, 18, 42, 0.4);
+  --ticker-surface-noise: var(--noise-subtle);
+  --ticker-ambient-mask:
+    radial-gradient(ellipse at 25% 30%, color-mix(in srgb, var(--accent) 40%, transparent) 0%, transparent 72%),
+    radial-gradient(ellipse at 72% 68%, color-mix(in srgb, var(--accent-secondary, var(--accent)) 52%, transparent) 0%, transparent 78%),
+    linear-gradient(160deg, rgba(8, 12, 22, 0.4), rgba(2, 6, 14, 0.88));
+  --ticker-ambient-opacity: 0.42;
+  --ticker-ambient-blur: 26px;
+  --ticker-accent-overlay:
+    linear-gradient(150deg,
+      color-mix(in srgb, var(--accent-bright) 82%, rgba(255, 255, 255, 0.2)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 68%, rgba(2, 6, 18, 0.78))
+    );
+  --ticker-accent-border: 2px solid color-mix(in srgb, var(--accent) 38%, rgba(255, 255, 255, 0.32));
+  --ticker-accent-glow: 0 0 30px color-mix(in srgb, var(--accent-secondary, var(--accent)) 26%, rgba(0, 0, 0, 0));
+  --ticker-accent-animation: auroraGradientShift 18s linear infinite;
+  --ticker-backdrop-filter: blur(24px) saturate(1.4);
+  --ticker-depth-filter: saturate(1.12) brightness(1.05);
   --ticker-label-width: calc(120px * var(--ui-scale));
+  --ticker-label-size: calc(13px * var(--ui-scale));
+  --ticker-label-weight: 800;
+  --ticker-label-letter: calc(2.6px * var(--ui-scale));
+  --ticker-label-color: rgba(234, 250, 255, 0.98);
+  --ticker-label-shadow: 0 0 16px color-mix(in srgb, var(--accent) 42%, rgba(0, 0, 0, 0.55));
+  --ticker-divider-color: rgba(108, 198, 255, 0.38);
+  --popup-surface-a: rgba(8, 14, 26, 0.94);
+  --popup-surface-b: rgba(2, 6, 14, 0.92);
+  --popup-border-color: rgba(68, 146, 202, 0.38);
+  --popup-shadow: 0 20px 54px rgba(0, 14, 36, 0.6);
+  --popup-text-color: rgba(230, 246, 255, 0.98);
+  --popup-divider-color: rgba(92, 168, 220, 0.32);
+  --popup-countdown-color: color-mix(in srgb, rgba(230, 242, 255, 0.9) 74%, var(--accent) 26%);
+  --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.56) 52%, var(--accent-secondary, var(--accent)) 48%);
+  --popup-accent-strip:
+    linear-gradient(170deg,
+      color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.18)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 52%, rgba(2, 6, 14, 0.78))
+    );
+}
+
+body.ticker--aurora-night .highlight,
+.ticker--aurora-night .highlight {
+  color: color-mix(in srgb, var(--accent-secondary, var(--accent)) 65%, rgba(255, 255, 255, 0.35));
+}
+
+/* Nexus Grid — technical lattice with pulsing nodes */
+.ticker--nexus-grid,
+body.ticker--nexus-grid {
+  --ticker-surface-a: rgba(8, 10, 20, 0.94);
+  --ticker-surface-b: rgba(5, 8, 16, 0.98);
+  --ticker-border: color-mix(in srgb, rgba(0, 255, 180, 0.38) 50%, rgba(6, 10, 18, 0.9));
+  --ticker-shadow:
+    0 22px 56px rgba(0, 12, 28, 0.55),
+    0 10px 28px rgba(0, 16, 28, 0.4);
+  --ticker-surface-noise: var(--noise-grain);
+  --ticker-ambient-mask:
+    radial-gradient(circle at 18% 22%, color-mix(in srgb, var(--accent) 36%, transparent) 0%, transparent 68%),
+    radial-gradient(circle at 82% 74%, color-mix(in srgb, var(--accent-secondary, var(--accent)) 36%, transparent) 0%, transparent 70%),
+    linear-gradient(145deg, rgba(8, 12, 18, 0.6), rgba(2, 6, 12, 0.92));
+  --ticker-ambient-opacity: 0.3;
+  --ticker-ambient-blur: 12px;
+  --ticker-accent-overlay:
+    linear-gradient(160deg,
+      color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.22)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 54%, rgba(2, 4, 10, 0.82))
+    );
+  --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 42%, rgba(255, 255, 255, 0.28));
+  --ticker-accent-glow: 0 0 24px color-mix(in srgb, var(--accent) 22%, rgba(0, 0, 0, 0));
+  --ticker-accent-animation: nexusGridPulse 14s var(--ease-circ) infinite;
+  --ticker-backdrop-filter: blur(22px) saturate(1.28);
+  --ticker-depth-filter: saturate(1.06) brightness(1.02);
+  --ticker-label-width: calc(108px * var(--ui-scale));
+  --ticker-label-size: calc(12px * var(--ui-scale));
+  --ticker-label-weight: 700;
+  --ticker-label-letter: calc(2.1px * var(--ui-scale));
+  --ticker-label-color: rgba(230, 244, 250, 0.95);
+  --ticker-label-shadow: 0 2px 10px rgba(0, 6, 16, 0.6);
+  --ticker-divider-color: rgba(120, 220, 200, 0.25);
+  --popup-surface-a: rgba(10, 14, 22, 0.94);
+  --popup-surface-b: rgba(6, 10, 18, 0.92);
+  --popup-border-color: rgba(68, 118, 138, 0.32);
+  --popup-shadow: 0 18px 48px rgba(0, 10, 22, 0.52);
+  --popup-text-color: rgba(230, 242, 248, 0.95);
+  --popup-divider-color: rgba(120, 200, 200, 0.28);
+  --popup-countdown-color: color-mix(in srgb, rgba(230, 242, 248, 0.88) 76%, var(--accent) 24%);
+  --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.5) 58%, var(--accent-secondary, var(--accent)) 42%);
+  --popup-accent-strip:
+    linear-gradient(170deg,
+      color-mix(in srgb, var(--accent) 74%, rgba(255, 255, 255, 0.2)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 42%, rgba(8, 12, 18, 0.78))
+    );
+}
+
+body.ticker--nexus-grid .highlight,
+.ticker--nexus-grid .highlight {
+  color: color-mix(in srgb, var(--accent) 68%, rgba(255, 255, 255, 0.28));
+}
+
+/* Zen Flow — tranquil organic morphing with soft light */
+.ticker--zen-flow,
+body.ticker--zen-flow {
+  --ticker-surface-a: rgba(10, 12, 22, 0.9);
+  --ticker-surface-b: rgba(6, 8, 18, 0.94);
+  --ticker-border: color-mix(in srgb, rgba(255, 255, 255, 0.32) 30%, rgba(10, 14, 24, 0.85));
+  --ticker-shadow:
+    0 18px 46px rgba(4, 6, 16, 0.5),
+    0 8px 24px rgba(6, 8, 18, 0.35);
+  --ticker-surface-noise: none;
+  --ticker-ambient-mask:
+    radial-gradient(circle at 20% 40%, color-mix(in srgb, var(--accent) 30%, transparent) 0%, transparent 70%),
+    radial-gradient(circle at 80% 60%, color-mix(in srgb, var(--accent-secondary, var(--accent)) 40%, transparent) 0%, transparent 74%),
+    linear-gradient(145deg, rgba(6, 8, 18, 0.65), rgba(2, 6, 14, 0.88));
+  --ticker-ambient-opacity: 0.28;
+  --ticker-ambient-blur: 28px;
+  --ticker-accent-overlay:
+    linear-gradient(160deg,
+      color-mix(in srgb, var(--accent) 72%, rgba(255, 255, 255, 0.2)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 48%, rgba(6, 8, 16, 0.7))
+    );
+  --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.32));
+  --ticker-accent-glow: 0 0 22px color-mix(in srgb, var(--accent-secondary, var(--accent)) 24%, rgba(0, 0, 0, 0));
+  --ticker-accent-animation: zenFlowDrift 24s var(--ease-premium) infinite;
+  --ticker-backdrop-filter: blur(26px) saturate(1.28);
+  --ticker-depth-filter: saturate(1.04) brightness(1.02);
+  --ticker-label-width: calc(108px * var(--ui-scale));
   --ticker-label-size: calc(12px * var(--ui-scale));
   --ticker-label-weight: 700;
   --ticker-label-letter: calc(1.8px * var(--ui-scale));
-  --ticker-label-color: rgba(244, 246, 252, 0.98);
-  --ticker-label-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.6);
-  --ticker-divider-color: rgba(255, 255, 255, 0.14);
-  --ticker-surface-noise: var(--noise-subtle);
-  --ticker-ambient-mask:
-    linear-gradient(180deg,
-      rgba(255, 255, 255, 0.04),
-      rgba(0, 0, 0, 0) 60%
-    );
-  --ticker-accent-overlay:
-    linear-gradient(160deg,
-      color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.1)),
-      color-mix(in srgb, var(--accent) 20%, rgba(8, 10, 16, 0.92))
-    );
-  --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.25));
-  --ticker-accent-glow:
-    0 0 18px color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.18));
-  --ticker-accent-animation: tickerAmbientGlow 18s var(--ease-smooth) infinite;
-  --ticker-backdrop-filter: blur(22px) saturate(1.05);
-  --ticker-depth-filter: saturate(1.02) brightness(1.02);
-  --popup-surface-a:
-    linear-gradient(180deg,
-      rgba(18, 20, 28, 0.94),
-      rgba(10, 12, 18, 0.94)
-    );
-  --popup-surface-b:
-    linear-gradient(200deg,
-      rgba(8, 10, 16, 0.92),
-      rgba(6, 7, 12, 0.94)
-    );
-  --popup-border-color: rgba(255, 255, 255, 0.1);
-  --popup-shadow:
-    0 18px 44px rgba(0, 0, 0, 0.5),
-    0 6px 18px rgba(0, 0, 0, 0.35);
-  --popup-text-color: rgba(244, 246, 252, 0.96);
-  --popup-divider-color: rgba(255, 255, 255, 0.12);
-  --popup-countdown-color: color-mix(in srgb, rgba(240, 242, 248, 0.92) 70%, var(--accent) 30%);
-  --popup-countdown-dot: color-mix(in srgb, rgba(250, 252, 255, 0.55) 60%, var(--accent) 40%);
-  --popup-accent-strip:
-    linear-gradient(180deg,
-      color-mix(in srgb, var(--accent) 68%, rgba(255, 255, 255, 0.1)),
-      color-mix(in srgb, var(--accent) 24%, rgba(6, 7, 12, 0.92))
-    );
-}
-
-.ticker--monotone .highlight,
-body.ticker--monotone .highlight {
-  color: rgba(225, 227, 235, 0.88);
-}
-
-/* HOLOGRAPHIC THEME - Futuristic iridescent surfaces */
-.ticker--holographic,
-body.ticker--holographic,
-.ticker--glass,
-body.ticker--glass {
-  --ticker-surface-a:
-    linear-gradient(135deg,
-      rgba(20, 25, 45, 0.92),
-      rgba(35, 20, 55, 0.88),
-      rgba(15, 35, 50, 0.94)
-    );
-  --ticker-surface-b:
-    linear-gradient(225deg,
-      rgba(8, 12, 28, 0.95),
-      rgba(18, 8, 35, 0.92),
-      rgba(5, 18, 25, 0.96)
-    );
-  --ticker-border:
-    linear-gradient(90deg,
-      rgba(120, 220, 255, 0.4),
-      rgba(255, 120, 220, 0.35),
-      rgba(120, 255, 180, 0.4)
-    );
-  --ticker-shadow:
-    0 24px 60px rgba(8, 15, 35, 0.5),
-    0 0 32px rgba(120, 200, 255, 0.14);
-  --ticker-backdrop-filter: blur(24px) saturate(1.4) hue-rotate(5deg);
-  --ticker-surface-noise: var(--noise-subtle);
-  --ticker-ambient-mask:
-    conic-gradient(from 45deg at 30% 20%,
-      rgba(120, 220, 255, 0.25) 0deg,
-      rgba(255, 120, 220, 0.2) 90deg,
-      rgba(120, 255, 180, 0.25) 180deg,
-      rgba(255, 200, 120, 0.2) 270deg,
-      rgba(120, 220, 255, 0.25) 360deg
-    ),
-    radial-gradient(ellipse 140% 100% at 70% 80%,
-      rgba(255, 120, 220, 0.18),
-      transparent 60%
-    );
-  --ticker-ambient-caustics:
-    repeating-conic-gradient(from 0deg at 40% 30%,
-      transparent 0deg 45deg,
-      rgba(120, 220, 255, 0.08) 45deg 90deg,
-      transparent 90deg 135deg,
-      rgba(255, 120, 220, 0.06) 135deg 180deg
-    );
-  --ticker-motion-stack:
-    tickerMaterialize 1.4s var(--ease-premium) both,
-    holographicShift 25s linear infinite,
-    quantumPulse 4.5s var(--ease-elastic) infinite 2s;
-  --ticker-label-width: calc(140px * var(--ui-scale));
-  --ticker-label-size: calc(13px * var(--ui-scale));
-  --ticker-label-weight: 800;
-  --ticker-label-letter: calc(2.5px * var(--ui-scale));
-  --ticker-label-color: rgba(255, 255, 255, 0.98);
-  --ticker-label-shadow:
-    0 0 8px rgba(120, 220, 255, 0.38),
-    0 1px 5px rgba(0, 0, 0, 0.45);
-  --ticker-divider-color:
-    linear-gradient(90deg,
-      rgba(120, 220, 255, 0.5),
-      rgba(255, 120, 220, 0.4),
-      rgba(120, 255, 180, 0.5)
-    );
-  --ticker-accent-overlay:
-    conic-gradient(from 30deg at 50% 0%,
-      rgba(120, 220, 255, 0.4) 0deg,
-      rgba(255, 120, 220, 0.35) 120deg,
-      rgba(120, 255, 180, 0.4) 240deg,
-      rgba(120, 220, 255, 0.4) 360deg
-    ),
-    linear-gradient(165deg,
-      rgba(255, 255, 255, 0.25) 0%,
-      transparent 40%
-    );
-  --ticker-accent-border: 2px solid transparent;
-  --ticker-accent-glow:
-    0 0 22px rgba(120, 220, 255, 0.28),
-    0 0 38px rgba(255, 120, 220, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.22);
-  --ticker-accent-animation: holographicShift 20s linear infinite;
-  --popup-surface-a:
-    linear-gradient(135deg,
-      rgba(25, 30, 50, 0.9),
-      rgba(40, 25, 60, 0.85),
-      rgba(20, 40, 55, 0.92)
-    );
-  --popup-surface-b:
-    linear-gradient(225deg,
-      rgba(12, 16, 32, 0.92),
-      rgba(22, 12, 40, 0.88),
-      rgba(8, 22, 30, 0.94)
-    );
-  --popup-border-color:
-    linear-gradient(45deg,
-      rgba(120, 220, 255, 0.35),
-      rgba(255, 120, 220, 0.3),
-      rgba(120, 255, 180, 0.35)
-    );
-  --popup-shadow:
-    0 28px 72px rgba(8, 15, 35, 0.5),
-    0 0 36px rgba(120, 200, 255, 0.16);
-  --popup-text-color: rgba(250, 252, 255, 0.98);
-  --popup-divider-color: rgba(180, 220, 255, 0.4);
-  --popup-countdown-color: rgba(240, 245, 255, 0.95);
-  --popup-countdown-dot: rgba(120, 220, 255, 0.8);
-  --popup-accent-strip:
-    linear-gradient(180deg,
-      rgba(120, 220, 255, 0.8),
-      rgba(255, 120, 220, 0.6),
-      rgba(120, 255, 180, 0.8)
-    );
-  --popup-sheen:
-    linear-gradient(125deg,
-      rgba(255, 255, 255, 0.3) 0%,
-      rgba(120, 220, 255, 0.15) 30%,
-      transparent 60%
-    );
-  --popup-glow-anim: holographicPulse 8s var(--ease-premium) infinite;
-}
-
-/* LIQUID GLASS THEME - Soft frosted layers with saturated highlights */
-.ticker--liquid-glass,
-body.ticker--liquid-glass {
-  --ticker-surface-a:
-    linear-gradient(135deg,
-      rgba(255, 255, 255, 0.82),
-      rgba(236, 238, 244, 0.86),
-      rgba(214, 220, 236, 0.88)
-    );
-  --ticker-surface-b:
-    linear-gradient(225deg,
-      rgba(226, 234, 248, 0.82),
-      rgba(206, 214, 232, 0.84),
-      rgba(190, 198, 216, 0.85)
-    );
-  --ticker-border: color-mix(in srgb, rgba(0, 82, 245, 0.35) 45%, rgba(255, 255, 255, 0.65) 55%);
-  --ticker-shadow:
-    0 22px 58px rgba(24, 30, 48, 0.35),
-    0 8px 28px rgba(12, 16, 30, 0.22);
-  --ticker-backdrop-filter: blur(26px) saturate(1.5) brightness(1.05);
-  --ticker-surface-noise: var(--noise-subtle);
-  --ticker-ambient-mask:
-    linear-gradient(120deg,
-      rgba(255, 255, 255, 0.18) 0%,
-      rgba(0, 82, 245, 0.12) 36%,
-      transparent 72%
-    ),
-    radial-gradient(circle at 18% 20%,
-      rgba(255, 255, 255, 0.24) 0%,
-      transparent 60%
-    ),
-    radial-gradient(circle at 80% 78%,
-      rgba(0, 82, 245, 0.16) 0%,
-      transparent 65%
-    );
-  --ticker-ambient-caustics:
-    repeating-linear-gradient(125deg,
-      transparent 0px 22px,
-      rgba(0, 82, 245, 0.08) 22px 28px,
-      transparent 28px 44px
-    ),
-    repeating-linear-gradient(-125deg,
-      transparent 0px 24px,
-      rgba(255, 255, 255, 0.06) 24px 30px,
-      transparent 30px 46px
-    );
-  --ticker-motion-stack:
-    tickerMaterialize 1.2s var(--ease-premium) both,
-    liquidGlassSweep 26s linear infinite,
-    liquidGlassPulse 6s var(--ease-premium) infinite 1.8s;
-  --ticker-label-width: calc(118px * var(--ui-scale));
-  --ticker-label-size: calc(12.5px * var(--ui-scale));
-  --ticker-label-weight: 700;
-  --ticker-label-letter: calc(2px * var(--ui-scale));
-  --ticker-label-color: rgba(34, 34, 68, 0.92);
-  --ticker-label-shadow:
-    0 0 6px rgba(255, 255, 255, 0.42),
-    0 1px 4px rgba(18, 24, 38, 0.32);
-  --ticker-divider-color:
-    linear-gradient(90deg,
-      color-mix(in srgb, rgba(0, 82, 245, 0.55) 60%, rgba(255, 255, 255, 0.45) 40%),
-      rgba(182, 198, 226, 0.6)
-    );
-  --ticker-accent-overlay:
-    radial-gradient(circle at 12% 18%,
-      rgba(255, 255, 255, 0.3) 0%,
-      transparent 55%
-    ),
-    radial-gradient(circle at 76% 68%,
-      rgba(0, 82, 245, 0.22) 0%,
-      transparent 60%
-    ),
-    linear-gradient(140deg,
-      color-mix(in srgb, var(--accent, #0052f5) 45%, rgba(255, 255, 255, 0.3)),
-      color-mix(in srgb, var(--accent, #0052f5) 30%, rgba(34, 34, 68, 0.35))
-    );
-  --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent, #0052f5) 55%, rgba(255, 255, 255, 0.7));
-  --ticker-accent-glow:
-    0 0 20px color-mix(in srgb, var(--accent, #0052f5) 32%, rgba(255, 255, 255, 0.4)),
-    0 0 36px rgba(34, 38, 64, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.35);
-  --ticker-accent-animation: liquidGlassSweep 22s var(--ease-premium) infinite;
-  --popup-surface-a:
-    linear-gradient(145deg,
-      rgba(255, 255, 255, 0.82),
-      rgba(236, 240, 248, 0.78)
-    );
-  --popup-surface-b:
-    linear-gradient(305deg,
-      rgba(224, 232, 250, 0.76),
-      rgba(206, 214, 234, 0.78)
-    );
-  --popup-border-color: color-mix(in srgb, rgba(0, 82, 245, 0.32) 55%, rgba(255, 255, 255, 0.6) 45%);
-  --popup-shadow:
-    0 26px 54px rgba(28, 32, 52, 0.3),
-    0 10px 24px rgba(12, 16, 30, 0.18);
-  --popup-text-color: rgba(34, 34, 68, 0.92);
-  --popup-divider-color: rgba(148, 168, 214, 0.45);
-  --popup-countdown-color: color-mix(in srgb, rgba(34, 34, 68, 0.85) 65%, var(--accent, #0052f5) 35%);
-  --popup-countdown-dot: color-mix(in srgb, var(--accent, #0052f5) 65%, rgba(255, 255, 255, 0.5) 35%);
-  --popup-accent-strip:
-    linear-gradient(180deg,
-      color-mix(in srgb, var(--accent, #0052f5) 60%, rgba(255, 255, 255, 0.45)),
-      color-mix(in srgb, var(--accent, #0052f5) 32%, rgba(34, 34, 68, 0.35))
-    );
-  --popup-sheen:
-    linear-gradient(120deg,
-      rgba(255, 255, 255, 0.35) 0%,
-      rgba(0, 82, 245, 0.2) 42%,
-      transparent 74%
-    );
-  --popup-glow-anim: liquidGlassPulse 14s var(--ease-premium) infinite;
-}
-
-/* NEURAL THEME - AI-inspired organic networks */
-.ticker--neural,
-body.ticker--neural,
-.ticker--mono,
-body.ticker--mono {
-  --ticker-surface-a: rgba(15, 18, 25, 0.94);
-  --ticker-surface-b: rgba(8, 10, 16, 0.96);
-  --ticker-border: rgba(0, 255, 150, 0.25);
-  --ticker-shadow:
-    0 20px 52px rgba(5, 8, 15, 0.52),
-    0 0 28px rgba(0, 255, 150, 0.12);
-  --ticker-backdrop-filter: blur(20px) saturate(1.3);
-  --ticker-surface-noise: var(--noise-grain);
-  --ticker-ambient-mask:
-    radial-gradient(ellipse 200% 150% at 20% 30%,
-      rgba(0, 255, 150, 0.15),
-      transparent 50%
-    ),
-    radial-gradient(ellipse 180% 120% at 80% 70%,
-      rgba(0, 180, 255, 0.12),
-      transparent 45%
-    ),
-    repeating-linear-gradient(45deg,
-      transparent 0px,
-      rgba(0, 255, 150, 0.03) 1px,
-      transparent 2px,
-      transparent 20px
-    );
-  --ticker-ambient-caustics:
-    radial-gradient(circle at 25% 25%, rgba(0, 255, 150, 0.1), transparent 30%),
-    radial-gradient(circle at 75% 75%, rgba(0, 180, 255, 0.08), transparent 35%),
-    linear-gradient(30deg,
-      rgba(0, 255, 150, 0.05) 0%,
-      transparent 20%,
-      rgba(0, 180, 255, 0.04) 40%,
-      transparent 60%
-    );
-  --ticker-motion-stack:
-    tickerMaterialize 1.1s var(--ease-expo) both,
-    neuralPulse 15s var(--ease-circ) infinite,
-    synapseFlicker 3.2s steps(8) infinite 1s;
-  --ticker-label-width: calc(110px * var(--ui-scale));
-  --ticker-label-size: calc(12.5px * var(--ui-scale));
-  --ticker-label-weight: 700;
-  --ticker-label-letter: calc(1.5px * var(--ui-scale));
-  --ticker-label-color: rgba(240, 255, 248, 0.96);
-  --ticker-label-shadow:
-    0 0 7px rgba(0, 255, 150, 0.32),
-    0 1px 5px rgba(0, 0, 0, 0.5);
-  --ticker-divider-color: rgba(0, 255, 150, 0.4);
-  --ticker-accent-overlay:
-    radial-gradient(ellipse 120% 200% at 40% 0%,
-      rgba(0, 255, 150, 0.3) 0%,
-      rgba(0, 180, 255, 0.2) 40%,
-      transparent 70%
-    ),
-    linear-gradient(45deg,
-      rgba(0, 255, 150, 0.15) 0%,
-      rgba(0, 180, 255, 0.1) 50%,
-      transparent 100%
-    ),
-    repeating-linear-gradient(90deg,
-      transparent 0px,
-      rgba(255, 255, 255, 0.05) 1px,
-      transparent 2px,
-      transparent 8px
-    );
-  --ticker-accent-border: 1px solid rgba(0, 255, 150, 0.4);
-  --ticker-accent-glow:
-    0 0 18px rgba(0, 255, 150, 0.24),
-    0 0 30px rgba(0, 180, 255, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
-  --ticker-accent-animation: neuralPulse 12s var(--ease-circ) infinite;
-  --popup-surface-a: rgba(18, 22, 30, 0.92);
-  --popup-surface-b: rgba(10, 12, 20, 0.94);
-  --popup-border-color: rgba(0, 255, 150, 0.3);
-  --popup-shadow:
-    0 24px 64px rgba(5, 8, 15, 0.52),
-    0 0 30px rgba(0, 255, 150, 0.12);
-  --popup-text-color: rgba(245, 252, 248, 0.97);
-  --popup-divider-color: rgba(0, 255, 150, 0.35);
-  --popup-countdown-color: rgba(235, 250, 242, 0.94);
-  --popup-countdown-dot: rgba(0, 255, 150, 0.8);
-  --popup-accent-strip:
-    linear-gradient(165deg,
-      rgba(0, 255, 150, 0.7),
-      rgba(0, 180, 255, 0.5)
-    );
-  --popup-sheen:
-    linear-gradient(130deg,
-      rgba(0, 255, 150, 0.2) 0%,
-      rgba(255, 255, 255, 0.1) 25%,
-      transparent 50%
-    );
-  --popup-glow-anim: neuralSync 10s var(--ease-expo) infinite;
-}
-
-/* QUANTUM THEME - Particle physics inspired */
-.ticker--quantum,
-body.ticker--quantum,
-.ticker--headline,
-body.ticker--headline {
-  --ticker-surface-a:
-    radial-gradient(ellipse at top, rgba(25, 15, 45, 0.9), rgba(15, 8, 30, 0.95)),
-    var(--surface-carbon);
-  --ticker-surface-b:
-    radial-gradient(ellipse at bottom, rgba(12, 6, 25, 0.96), rgba(8, 4, 18, 0.98)),
-    rgba(5, 3, 12, 0.98);
-  --ticker-border: rgba(180, 100, 255, 0.3);
-  --ticker-shadow:
-    0 26px 70px rgba(8, 4, 20, 0.55),
-    0 0 36px rgba(180, 100, 255, 0.16);
-  --ticker-backdrop-filter: blur(22px) saturate(1.5) contrast(1.1);
-  --ticker-surface-noise: var(--noise-subtle);
-  --ticker-ambient-mask:
-    radial-gradient(circle at 30% 20%,
-      rgba(180, 100, 255, 0.2) 0%,
-      transparent 40%
-    ),
-    radial-gradient(circle at 70% 80%,
-      rgba(100, 150, 255, 0.15) 0%,
-      transparent 35%
-    ),
-    conic-gradient(from 180deg at 50% 50%,
-      transparent 0deg,
-      rgba(180, 100, 255, 0.08) 90deg,
-      transparent 180deg,
-      rgba(100, 150, 255, 0.06) 270deg,
-      transparent 360deg
-    );
-  --ticker-ambient-caustics:
-    repeating-radial-gradient(ellipse at 40% 40%,
-      transparent 0px,
-      rgba(180, 100, 255, 0.05) 20px,
-      transparent 40px,
-      rgba(100, 150, 255, 0.04) 60px,
-      transparent 80px
-    );
-  --ticker-motion-stack:
-    tickerMaterialize 1.3s var(--ease-back) both,
-    quantumFlux 18s var(--ease-premium) infinite,
-    particleWave 5s var(--ease-elastic) infinite 1.5s;
-  --ticker-label-width: calc(125px * var(--ui-scale));
-  --ticker-label-size: calc(13px * var(--ui-scale));
-  --ticker-label-weight: 800;
-  --ticker-label-letter: calc(2px * var(--ui-scale));
-  --ticker-label-color: rgba(250, 245, 255, 0.98);
-  --ticker-label-shadow:
-    0 0 9px rgba(180, 100, 255, 0.4),
-    0 1px 6px rgba(0, 0, 0, 0.6);
-  --ticker-divider-color:
-    linear-gradient(45deg,
-      rgba(180, 100, 255, 0.5),
-      rgba(100, 150, 255, 0.4)
-    );
-  --ticker-accent-overlay:
-    radial-gradient(ellipse 150% 100% at 30% 0%,
-      rgba(180, 100, 255, 0.35) 0%,
-      rgba(100, 150, 255, 0.25) 50%,
-      transparent 80%
-    ),
-    linear-gradient(135deg,
-      rgba(255, 255, 255, 0.2) 0%,
-      rgba(180, 100, 255, 0.1) 30%,
-      transparent 60%
-    ),
-    repeating-linear-gradient(60deg,
-      transparent 0px,
-      rgba(255, 255, 255, 0.03) 2px,
-      transparent 4px,
-      transparent 12px
-    );
-  --ticker-accent-border: 2px solid rgba(180, 100, 255, 0.4);
-  --ticker-accent-glow:
-    0 0 24px rgba(180, 100, 255, 0.28),
-    0 0 42px rgba(100, 150, 255, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.16);
-  --ticker-accent-animation: quantumFlux 20s var(--ease-premium) infinite;
-  --popup-surface-a:
-    radial-gradient(ellipse at top, rgba(30, 20, 50, 0.88), rgba(20, 12, 35, 0.92)),
-    var(--surface-carbon);
-  --popup-surface-b:
-    radial-gradient(ellipse at bottom, rgba(15, 8, 30, 0.94), rgba(12, 6, 22, 0.96));
-  --popup-border-color: rgba(180, 100, 255, 0.35);
-  --popup-shadow:
-    0 30px 80px rgba(8, 4, 20, 0.55),
-    0 0 36px rgba(180, 100, 255, 0.18);
-  --popup-text-color: rgba(248, 245, 255, 0.98);
-  --popup-divider-color: rgba(180, 120, 255, 0.4);
-  --popup-countdown-color: rgba(245, 240, 255, 0.96);
-  --popup-countdown-dot: rgba(180, 100, 255, 0.85);
+  --ticker-label-color: rgba(236, 242, 250, 0.96);
+  --ticker-label-shadow: 0 2px 8px rgba(4, 6, 16, 0.5);
+  --ticker-divider-color: rgba(255, 255, 255, 0.18);
+  --popup-surface-a: rgba(12, 14, 24, 0.9);
+  --popup-surface-b: rgba(6, 8, 18, 0.9);
+  --popup-border-color: rgba(118, 134, 178, 0.32);
+  --popup-shadow: 0 18px 44px rgba(4, 6, 16, 0.5);
+  --popup-text-color: rgba(236, 242, 250, 0.95);
+  --popup-divider-color: rgba(108, 130, 172, 0.32);
+  --popup-countdown-color: color-mix(in srgb, rgba(236, 242, 250, 0.88) 76%, var(--accent) 24%);
+  --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.5) 58%, var(--accent-secondary, var(--accent)) 42%);
   --popup-accent-strip:
     linear-gradient(175deg,
-      rgba(180, 100, 255, 0.8),
-      rgba(100, 150, 255, 0.6)
+      color-mix(in srgb, var(--accent) 72%, rgba(255, 255, 255, 0.18)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 46%, rgba(6, 8, 16, 0.72))
     );
-  --popup-sheen:
-    linear-gradient(120deg,
-      rgba(180, 100, 255, 0.25) 0%,
-      rgba(255, 255, 255, 0.15) 35%,
-      transparent 65%
-    );
-  --popup-glow-anim: quantumResonance 12s var(--ease-back) infinite;
 }
 
-/* CRYSTALLINE THEME - Precision geometric surfaces */
-.ticker--crystalline,
-body.ticker--crystalline,
-.ticker--minimal,
-body.ticker--minimal {
-  --ticker-surface-a:
-    linear-gradient(120deg, rgba(12, 18, 28, 0.95), rgba(18, 25, 38, 0.92)),
-    var(--surface-glass-dark);
-  --ticker-surface-b:
-    linear-gradient(300deg, rgba(6, 10, 18, 0.98), rgba(10, 15, 25, 0.96));
-  --ticker-border: rgba(100, 200, 255, 0.4);
-  --ticker-shadow:
-    0 20px 56px rgba(5, 10, 20, 0.5),
-    0 0 28px rgba(100, 200, 255, 0.14);
-  --ticker-backdrop-filter: blur(18px) saturate(1.2) brightness(1.05);
-  --ticker-surface-noise: none;
-  --ticker-ambient-mask:
-    linear-gradient(135deg,
-      rgba(100, 200, 255, 0.18) 0%,
-      transparent 40%,
-      rgba(150, 180, 255, 0.12) 70%,
-      transparent 100%
-    ),
-    repeating-linear-gradient(30deg,
-      transparent 0px,
-      rgba(255, 255, 255, 0.02) 1px,
-      transparent 2px,
-      transparent 40px
-    );
-  --ticker-ambient-caustics:
-    linear-gradient(60deg,
-      rgba(100, 200, 255, 0.08) 0%,
-      transparent 25%,
-      rgba(150, 180, 255, 0.06) 50%,
-      transparent 75%
-    ),
-    repeating-linear-gradient(120deg,
-      transparent 0px,
-      rgba(255, 255, 255, 0.05) 2px,
-      transparent 4px,
-      transparent 20px
-    );
-  --ticker-motion-stack:
-    tickerMaterialize 0.9s var(--ease-circ) both,
-    crystallineRefraction 22s linear infinite,
-    prismShimmer 6s var(--ease-premium) infinite 2.5s;
-  --ticker-label-width: calc(95px * var(--ui-scale));
-  --ticker-label-size: calc(12px * var(--ui-scale));
-  --ticker-label-weight: 600;
-  --ticker-label-letter: calc(1px * var(--ui-scale));
-  --ticker-label-color: rgba(245, 250, 255, 0.95);
-  --ticker-label-shadow:
-    0 0 5px rgba(100, 200, 255, 0.32),
-    0 1px 4px rgba(0, 0, 0, 0.45);
-  --ticker-divider-color: rgba(120, 190, 255, 0.3);
-  --ticker-accent-overlay:
-    linear-gradient(45deg,
-      rgba(100, 200, 255, 0.25) 0%,
-      rgba(150, 180, 255, 0.2) 50%,
-      transparent 100%
-    ),
-    repeating-linear-gradient(135deg,
-      rgba(255, 255, 255, 0.08) 0px,
-      transparent 1px,
-      rgba(100, 200, 255, 0.05) 2px,
-      transparent 3px,
-      transparent 30px
-    );
-  --ticker-accent-border: 1px solid rgba(120, 190, 255, 0.5);
-  --ticker-accent-glow:
-    0 0 16px rgba(100, 200, 255, 0.26),
-    inset 0 1px 0 rgba(255, 255, 255, 0.18),
-    inset 0 -1px 0 rgba(100, 200, 255, 0.08);
-  --ticker-accent-animation: crystallineRefraction 18s linear infinite;
-  --popup-surface-a:
-    linear-gradient(120deg, rgba(15, 22, 32, 0.92), rgba(22, 30, 42, 0.88));
-  --popup-surface-b:
-    linear-gradient(300deg, rgba(8, 12, 22, 0.95), rgba(12, 18, 30, 0.92));
-  --popup-border-color: rgba(120, 190, 255, 0.35);
-  --popup-shadow:
-    0 24px 68px rgba(5, 10, 20, 0.52),
-    0 0 28px rgba(100, 200, 255, 0.16);
-  --popup-text-color: rgba(242, 248, 255, 0.96);
-  --popup-divider-color: rgba(130, 180, 255, 0.3);
-  --popup-countdown-color: rgba(238, 245, 255, 0.94);
-  --popup-countdown-dot: rgba(120, 190, 255, 0.8);
-  --popup-accent-strip:
-    linear-gradient(180deg,
-      rgba(100, 200, 255, 0.6),
-      rgba(150, 180, 255, 0.4)
-    );
-  --popup-sheen:
-    linear-gradient(135deg,
-      rgba(255, 255, 255, 0.2) 0%,
-      rgba(100, 200, 255, 0.1) 40%,
-      transparent 70%
-    );
-  --popup-glow-anim: crystallinePulse 16s var(--ease-circ) infinite;
+body.ticker--zen-flow .highlight,
+.ticker--zen-flow .highlight {
+  color: color-mix(in srgb, var(--accent-secondary, var(--accent)) 60%, rgba(255, 255, 255, 0.4));
 }
 
-/* NEON NOIR THEME - Cyberpunk elegance */
-.ticker--neon-noir,
-body.ticker--neon-noir,
-.ticker--contrast,
-body.ticker--contrast {
-  --ticker-surface-a: rgba(8, 4, 12, 0.96);
-  --ticker-surface-b: rgba(4, 2, 8, 0.98);
-  --ticker-border: rgba(255, 0, 120, 0.4);
+/* Duotone Fusion — confident dual-colour gradients */
+.ticker--duotone-fusion,
+body.ticker--duotone-fusion {
+  --ticker-surface-a: rgba(6, 8, 18, 0.95);
+  --ticker-surface-b: rgba(2, 4, 10, 0.98);
+  --ticker-border: color-mix(in srgb, var(--accent-secondary, var(--accent)) 35%, rgba(255, 255, 255, 0.24));
   --ticker-shadow:
-    0 28px 80px rgba(4, 2, 10, 0.6),
-    0 0 36px rgba(255, 0, 120, 0.2);
-  --ticker-backdrop-filter: blur(24px) saturate(1.6) contrast(1.2);
-  --ticker-surface-noise: var(--noise-grain);
+    0 24px 62px rgba(4, 6, 18, 0.58),
+    0 10px 32px rgba(6, 8, 16, 0.42);
+  --ticker-surface-noise: var(--noise-subtle);
   --ticker-ambient-mask:
-    radial-gradient(ellipse 150% 100% at 25% 0%,
-      rgba(255, 0, 120, 0.2) 0%,
-      transparent 50%
-    ),
-    radial-gradient(ellipse 120% 150% at 75% 100%,
-      rgba(0, 255, 200, 0.15) 0%,
-      transparent 45%
-    ),
-    repeating-linear-gradient(45deg,
-      transparent 0px,
-      rgba(255, 0, 120, 0.05) 2px,
-      transparent 4px,
-      rgba(0, 255, 200, 0.03) 6px,
-      transparent 8px,
-      transparent 40px
-    );
-  --ticker-ambient-caustics:
-    linear-gradient(30deg,
-      rgba(255, 0, 120, 0.1) 0%,
-      transparent 30%,
-      rgba(0, 255, 200, 0.08) 60%,
-      transparent 90%
-    ),
-    repeating-linear-gradient(120deg,
-      transparent 0px,
-      rgba(255, 255, 255, 0.08) 1px,
-      transparent 2px,
-      transparent 16px
-    );
-  --ticker-motion-stack:
-    tickerMaterialize 1.15s var(--ease-premium) both,
-    neonNoirSweep 14s linear infinite,
-    neonNoirPulse 6s var(--ease-back) infinite 1.8s;
-  --ticker-label-width: calc(118px * var(--ui-scale));
-  --ticker-label-size: calc(12.5px * var(--ui-scale));
-  --ticker-label-weight: 800;
-  --ticker-label-letter: calc(2px * var(--ui-scale));
-  --ticker-label-color: rgba(255, 248, 252, 0.98);
-  --ticker-label-shadow:
-    0 0 10px rgba(255, 0, 120, 0.38),
-    0 1px 6px rgba(0, 0, 0, 0.65);
-  --ticker-divider-color: rgba(255, 0, 120, 0.5);
-  --ticker-accent-overlay:
     linear-gradient(160deg,
-      rgba(255, 0, 120, 0.35),
-      rgba(0, 255, 200, 0.28)
-    ),
-    repeating-linear-gradient(45deg,
-      rgba(255, 0, 120, 0.1) 0px,
-      transparent 2px,
-      rgba(0, 255, 200, 0.06) 4px,
-      transparent 8px
+      color-mix(in srgb, var(--accent) 26%, transparent),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 38%, transparent)
     );
-  --ticker-accent-border: 2px solid rgba(255, 0, 120, 0.45);
-  --ticker-accent-glow:
-    0 0 26px rgba(255, 0, 120, 0.32),
-    0 0 44px rgba(0, 255, 200, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.2);
-  --ticker-accent-animation: neonNoirSweep 16s linear infinite;
-  --popup-surface-a: rgba(14, 6, 20, 0.95);
-  --popup-surface-b: rgba(8, 4, 12, 0.98);
-  --popup-border-color: rgba(255, 0, 120, 0.35);
-  --popup-shadow:
-    0 28px 82px rgba(4, 2, 10, 0.6),
-    0 0 38px rgba(255, 0, 120, 0.22);
-  --popup-text-color: rgba(255, 245, 250, 0.99);
-  --popup-divider-color: rgba(255, 0, 120, 0.4);
-  --popup-countdown-color: rgba(250, 240, 248, 0.97);
-  --popup-countdown-dot: rgba(0, 255, 200, 0.85);
+  --ticker-ambient-opacity: 0.36;
+  --ticker-ambient-blur: 20px;
+  --ticker-accent-overlay:
+    linear-gradient(150deg,
+      color-mix(in srgb, var(--accent) 72%, rgba(255, 255, 255, 0.22)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 68%, rgba(4, 6, 16, 0.72))
+    );
+  --ticker-accent-border: 2px solid color-mix(in srgb, var(--accent) 32%, rgba(255, 255, 255, 0.26));
+  --ticker-accent-glow: 0 0 30px color-mix(in srgb, var(--accent-secondary, var(--accent)) 30%, rgba(0, 0, 0, 0));
+  --ticker-accent-animation: duotoneShift 16s ease-in-out infinite;
+  --ticker-backdrop-filter: blur(24px) saturate(1.4);
+  --ticker-depth-filter: saturate(1.1) brightness(1.06);
+  --ticker-label-width: calc(122px * var(--ui-scale));
+  --ticker-label-size: calc(13px * var(--ui-scale));
+  --ticker-label-weight: 820;
+  --ticker-label-letter: calc(2.8px * var(--ui-scale));
+  --ticker-label-color: rgba(245, 248, 255, 0.98);
+  --ticker-label-shadow:
+    0 0 12px color-mix(in srgb, var(--accent) 48%, rgba(0, 0, 0, 0.45)),
+    0 0 22px color-mix(in srgb, var(--accent-secondary, var(--accent)) 38%, rgba(0, 0, 0, 0.32));
+  --ticker-divider-color: color-mix(in srgb, var(--accent) 38%, rgba(255, 255, 255, 0.32));
+  --popup-surface-a: rgba(10, 12, 22, 0.95);
+  --popup-surface-b: rgba(4, 6, 16, 0.95);
+  --popup-border-color: color-mix(in srgb, var(--accent-secondary, var(--accent)) 42%, rgba(255, 255, 255, 0.28));
+  --popup-shadow: 0 24px 56px rgba(4, 6, 16, 0.58);
+  --popup-text-color: rgba(244, 246, 255, 0.98);
+  --popup-divider-color: rgba(255, 255, 255, 0.22);
+  --popup-countdown-color: color-mix(in srgb, rgba(240, 242, 255, 0.92) 70%, var(--accent) 30%);
+  --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.52) 52%, var(--accent-secondary, var(--accent)) 48%);
   --popup-accent-strip:
-    linear-gradient(170deg,
-      rgba(255, 0, 120, 0.8),
-      rgba(0, 255, 200, 0.55)
+    linear-gradient(175deg,
+      color-mix(in srgb, var(--accent) 72%, rgba(255, 255, 255, 0.18)),
+      color-mix(in srgb, var(--accent-secondary, var(--accent)) 68%, rgba(6, 8, 16, 0.68))
     );
-  --popup-sheen:
-    linear-gradient(125deg,
-      rgba(255, 255, 255, 0.18) 0%,
-      rgba(0, 255, 200, 0.12) 32%,
-      transparent 65%
-    );
-  --popup-glow-anim: neonNoirPulse 10s var(--ease-back) infinite;
 }
 
-/* Motion library */
-@keyframes liquidGlassSweep {
-  0% {
-    background-position: 0% 50%, 0% 0%, 0% 0%;
-    filter: saturate(1) brightness(1);
-  }
-  35% {
-    background-position: 60% 45%, 30% 20%, 80% 40%;
-    filter: saturate(1.08) brightness(1.04);
-  }
-  65% {
-    background-position: 120% 55%, 70% 60%, 150% 85%;
-    filter: saturate(1.12) brightness(1.05);
-  }
-  100% {
-    background-position: 200% 50%, 100% 70%, 220% 110%;
-    filter: saturate(1.02) brightness(1);
-  }
+body.ticker--duotone-fusion .highlight,
+.ticker--duotone-fusion .highlight {
+  color: color-mix(in srgb, var(--accent-secondary, var(--accent)) 72%, rgba(255, 255, 255, 0.32));
 }
 
-@keyframes liquidGlassPulse {
-  0%, 100% {
-    opacity: 0.72;
-    filter: saturate(1) brightness(1);
-  }
-  40% {
-    opacity: 0.98;
-    filter: saturate(1.18) brightness(1.06);
-  }
-  70% {
-    opacity: 0.86;
-    filter: saturate(1.08) brightness(1.03);
-  }
+/* Keyframes */
+@keyframes labelPulse {
+  0%, 100% { opacity: 1; transform: translateY(0); }
+  50% { opacity: 0.88; transform: translateY(-6px); }
 }
 
 @keyframes tickerMaterialize {
-  0% {
-    opacity: 0;
-    filter: blur(6px) saturate(0.8);
-  }
-  60% {
-    opacity: 1;
-    filter: blur(0px) saturate(1.08);
-  }
-  100% {
-    opacity: 1;
-    filter: none;
-  }
-}
-
-@keyframes holographicShift {
-  0% { background-position: 0% 50%, 0% 0%; filter: hue-rotate(0deg) saturate(1); }
-  50% { background-position: 120% 50%, 60% 40%; filter: hue-rotate(8deg) saturate(1.12); }
-  100% { background-position: 240% 50%, 120% 80%; filter: hue-rotate(2deg) saturate(1.04); }
-}
-
-@keyframes quantumPulse {
-  0%, 100% { filter: saturate(1) brightness(1); }
-  50% { filter: saturate(1.08) brightness(1.05); }
-}
-
-@keyframes holographicPulse {
-  0%, 100% { opacity: 0.6; filter: saturate(1); }
-  40% { opacity: 0.8; filter: saturate(1.06); }
-}
-
-@keyframes neuralPulse {
-  0%, 100% { background-position: 0% 50%, 0% 0%; }
-  50% { background-position: 90% 60%, 50% 20%; }
-}
-
-@keyframes synapseFlicker {
-  0%, 100% { opacity: 0.85; }
-  20% { opacity: 1; }
-  40% { opacity: 0.6; }
-  70% { opacity: 0.95; }
-}
-
-@keyframes neuralSync {
-  0%, 100% { box-shadow: 0 0 18px rgba(0, 255, 150, 0.2), 0 0 32px rgba(0, 180, 255, 0.12); }
-  50% { box-shadow: 0 0 28px rgba(0, 255, 150, 0.26), 0 0 44px rgba(0, 180, 255, 0.16); }
-}
-
-@keyframes ambientFlow {
-  0% { mask-position: 0% 0%; }
-  100% { mask-position: 200% 100%; }
-}
-
-@keyframes quantumFlux {
-  0% { background-position: 0% 50%, 0% 0%; filter: saturate(0.95); }
-  50% { background-position: 140% 60%, 70% 40%; filter: saturate(1.1); }
-  100% { background-position: 280% 50%, 120% 80%; filter: saturate(1.02); }
-}
-
-@keyframes particleWave {
-  0%, 100% { transform: translateY(0); }
-  35% { transform: translateY(-4px); }
-  65% { transform: translateY(2px); }
-}
-
-@keyframes quantumResonance {
-  0%, 100% { box-shadow: 0 0 22px rgba(180, 100, 255, 0.26), 0 0 48px rgba(100, 150, 255, 0.16); }
-  50% { box-shadow: 0 0 32px rgba(180, 100, 255, 0.32), 0 0 60px rgba(100, 150, 255, 0.2); }
-}
-
-@keyframes crystallineRefraction {
-  0% { background-position: 0% 50%, 0% 0%; }
-  50% { background-position: 120% 60%, 60% 30%; }
-  100% { background-position: 240% 50%, 120% 70%; }
-}
-
-@keyframes prismShimmer {
-  0%, 100% { filter: saturate(1) brightness(1); }
-  50% { filter: saturate(1.08) brightness(1.06); }
-}
-
-@keyframes crystallinePulse {
-  0%, 100% { opacity: 0.82; }
-  50% { opacity: 1; }
-}
-
-@keyframes neonNoirSweep {
-  0% { background-position: 0% 40%, 0% 0%; }
-  50% { background-position: 160% 60%, 80% 40%; }
-  100% { background-position: 320% 80%, 120% 60%; }
-}
-
-@keyframes neonNoirPulse {
-  0%, 100% { box-shadow: 0 0 24px rgba(255, 0, 120, 0.3), 0 0 44px rgba(0, 255, 200, 0.18); }
-  45% { box-shadow: 0 0 34px rgba(255, 0, 120, 0.36), 0 0 56px rgba(0, 255, 200, 0.22); }
+  0% { opacity: 0; filter: blur(8px) saturate(0.6); }
+  60% { opacity: 1; filter: blur(0px) saturate(1.08); }
+  100% { opacity: 1; filter: none; }
 }
 
 @keyframes textScramble {
@@ -900,8 +331,43 @@ body.ticker--contrast {
   100% { filter: blur(0px); opacity: 1; }
 }
 
+@keyframes ambientFlow {
+  0% { mask-position: 0% 0%; }
+  100% { mask-position: 200% 100%; }
+}
+
 @keyframes tickerAmbientGlow {
-  0%, 100% { opacity: 0.22; filter: saturate(1) brightness(1); }
-  40% { opacity: 0.32; filter: saturate(1.04) brightness(1.03); }
-  70% { opacity: 0.26; filter: saturate(1.02) brightness(1.01); }
+  0%, 100% { opacity: var(--ticker-ambient-opacity); filter: saturate(1) brightness(1); }
+  40% { opacity: calc(var(--ticker-ambient-opacity) + 0.12); filter: saturate(1.08) brightness(1.05); }
+  70% { opacity: calc(var(--ticker-ambient-opacity) - 0.06); filter: saturate(1.02) brightness(1.02); }
+}
+
+@keyframes midnightGlassSweep {
+  0% { background-position: 0% 50%; filter: hue-rotate(0deg) saturate(1); }
+  50% { background-position: 120% 50%; filter: hue-rotate(6deg) saturate(1.08); }
+  100% { background-position: 240% 50%; filter: hue-rotate(2deg) saturate(1.02); }
+}
+
+@keyframes auroraGradientShift {
+  0% { background-position: 0% 30%; filter: hue-rotate(0deg); }
+  50% { background-position: 140% 60%; filter: hue-rotate(10deg); }
+  100% { background-position: 280% 40%; filter: hue-rotate(2deg); }
+}
+
+@keyframes nexusGridPulse {
+  0%, 100% { filter: saturate(1) brightness(1); }
+  40% { filter: saturate(1.1) brightness(1.05); }
+  70% { filter: saturate(1.04) brightness(1.02); }
+}
+
+@keyframes zenFlowDrift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 80% 60%; }
+  100% { background-position: 160% 40%; }
+}
+
+@keyframes duotoneShift {
+  0% { background-position: 0% 50%; filter: saturate(1); }
+  50% { background-position: 180% 50%; filter: saturate(1.15); }
+  100% { background-position: 360% 50%; filter: saturate(1); }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -493,12 +493,6 @@
       mask-repeat: no-repeat;
       -webkit-mask-repeat: no-repeat;
       animation: var(--popup-glow-anim, none);
-      --preview-accent: #ef4444;
-      --accent: var(--preview-accent);
-      --accent-bright: color-mix(in srgb, var(--accent) 80%, #f8f9ff 20%);
-      --accent-glow: color-mix(in srgb, var(--accent) 56%, rgba(255, 255, 255, 0.4));
-      --accent-duo: color-mix(in srgb, var(--accent) 60%, #1c1e27 40%);
-      --accent-contrast: color-mix(in srgb, var(--accent) 56%, #0d0f16 44%);
       --ticker-surface-a: rgba(16, 18, 26, 0.94);
       --ticker-surface-b: rgba(6, 8, 14, 0.92);
       --ticker-border: rgba(120, 126, 146, 0.24);
@@ -510,10 +504,18 @@
       --popup-shadow: var(--ticker-shadow);
       --popup-text-color: rgba(248, 250, 255, 0.96);
       --popup-divider-color: color-mix(in srgb, var(--ticker-divider-color) 78%, rgba(255, 255, 255, 0.12));
+      --preview-accent: #38bdf8;
+      --preview-accent-secondary: #f472b6;
+      --accent: var(--preview-accent);
+      --accent-secondary: var(--preview-accent-secondary, var(--accent));
+      --accent-bright: color-mix(in srgb, var(--accent) 80%, #f8f9ff 20%);
+      --accent-glow: color-mix(in srgb, var(--accent) 56%, rgba(255, 255, 255, 0.4));
+      --accent-duo: color-mix(in srgb, var(--accent) 60%, #1c1e27 40%);
+      --accent-contrast: color-mix(in srgb, var(--accent) 56%, #0d0f16 44%);
       --popup-countdown-color: color-mix(in srgb, rgba(247, 249, 255, 0.9) 85%, var(--accent) 15%);
       --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.52) 75%, var(--accent) 25%);
       --popup-accent-strip:
-        linear-gradient(165deg, var(--accent), color-mix(in srgb, var(--accent) 32%, rgba(255, 255, 255, 0.45)));
+        linear-gradient(165deg, var(--accent), color-mix(in srgb, var(--accent-secondary) 32%, rgba(255, 255, 255, 0.45)));
       --popup-sheen: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0) 65%);
     }
     .popup-preview::before {
@@ -1264,10 +1266,18 @@
             <div class="control-group">
               <label for="overlayAccent">Accent Colour</label>
               <div class="accent-inputs" id="overlayAccentGroup">
-                <input type="color" id="overlayAccentPicker" aria-label="Accent colour" value="#ef4444" />
-                <input type="text" id="overlayAccent" placeholder="#ef4444" autocomplete="off" spellcheck="false" />
+                <input type="color" id="overlayAccentPicker" aria-label="Accent colour" value="#38bdf8" />
+                <input type="text" id="overlayAccent" placeholder="#38bdf8" autocomplete="off" spellcheck="false" />
               </div>
               <p class="control-hint" id="overlayAccentHint">Accepts hex (#ff0000), rgb(a), hsl(a), or named colours.</p>
+            </div>
+            <div class="control-group">
+              <label for="overlayAccentSecondary">Accent Colour B</label>
+              <div class="accent-inputs" id="overlayAccentSecondaryGroup">
+                <input type="color" id="overlayAccentSecondaryPicker" aria-label="Secondary accent colour" value="#f472b6" />
+                <input type="text" id="overlayAccentSecondary" placeholder="#f472b6" autocomplete="off" spellcheck="false" />
+              </div>
+              <p class="control-hint" id="overlayAccentSecondaryHint">Optional second highlight used by Duotone Fusion and blended gradients.</p>
             </div>
             <div class="control-group">
               <label for="highlightWords">Highlight Words (comma separated)</label>
@@ -1307,20 +1317,18 @@
           <div class="control-group">
             <label>Theme</label>
               <div class="segment-row" id="themeButtons">
-                <button type="button" class="segment-button" data-theme="holographic">Holographic</button>
-                <button type="button" class="segment-button" data-theme="neural">Neural</button>
-                <button type="button" class="segment-button" data-theme="quantum">Quantum</button>
-                <button type="button" class="segment-button" data-theme="crystalline">Crystalline</button>
-                <button type="button" class="segment-button" data-theme="neon-noir">Neon Noir</button>
-                <button type="button" class="segment-button" data-theme="monotone">Monotone</button>
+                <button type="button" class="segment-button" data-theme="midnight-glass">Midnight Glass</button>
+                <button type="button" class="segment-button" data-theme="aurora-night">Aurora Night</button>
+                <button type="button" class="segment-button" data-theme="nexus-grid">Nexus Grid</button>
+                <button type="button" class="segment-button" data-theme="zen-flow">Zen Flow</button>
+                <button type="button" class="segment-button" data-theme="duotone-fusion">Duotone Fusion</button>
               </div>
               <div class="theme-notes">
-                <span><strong>Holographic</strong> iridescent refraction with caustic light</span>
-                <span><strong>Neural</strong> AI-inspired circuitry with pulsing glow</span>
-                <span><strong>Quantum</strong> particle gradients and energetic beams</span>
-                <span><strong>Crystalline</strong> precision glass facets and cool sheen</span>
-                <span><strong>Neon Noir</strong> cyberpunk neon with deep contrast</span>
-                <span><strong>Monotone</strong> graphite minimalism with accent highlights</span>
+                <span><strong>Midnight Glass</strong> frosted panes with ambient PixiJS particles</span>
+                <span><strong>Aurora Night</strong> flowing shader ribbons reacting to your accent colours</span>
+                <span><strong>Nexus Grid</strong> animated network lattice with responsive nodes</span>
+                <span><strong>Zen Flow</strong> tranquil Lottie morphing shapes for calm motion</span>
+                <span><strong>Duotone Fusion</strong> bold dual-colour gradients and reactive highlights</span>
               </div>
           </div>
           <div class="toggle-row">
@@ -1539,7 +1547,7 @@
         ? BASE_THEME_OPTIONS.slice()
         : (Array.isArray(OVERLAY_THEMES) && OVERLAY_THEMES.length
             ? OVERLAY_THEMES
-            : ['holographic', 'liquid-glass', 'neural', 'quantum', 'crystalline', 'neon-noir', 'monotone']);
+            : ['midnight-glass', 'aurora-night', 'nexus-grid', 'zen-flow', 'duotone-fusion']);
     const THEME_CLASSNAMES = THEME_OPTIONS.map(theme => `ticker--${theme}`);
     const MAX_PRESET_NAME_LENGTH = 80;
     const MAX_SCENE_NAME_LENGTH = 80;
@@ -1554,6 +1562,7 @@
     const SCENE_OVERLAY_KEYS = [
       'label',
       'accent',
+      'accentSecondary',
       'highlight',
       'scale',
       'popupScale',
@@ -1578,7 +1587,8 @@
 
     const DEFAULT_OVERLAY = {
       label: 'LIVE',
-      accent: '#ef4444',
+      accent: '#38bdf8',
+      accentSecondary: '#f472b6',
       highlight: DEFAULT_HIGHLIGHT_STRING,
       scale: 1.75,
       popupScale: 1,
@@ -1586,7 +1596,7 @@
       mode: 'auto',
       accentAnim: true,
       sparkle: true,
-      theme: 'monotone',
+      theme: 'midnight-glass',
       ...(BASE_DEFAULT_OVERLAY || {}),
       ...(sharedConfig.DEFAULT_OVERLAY || {})
     };
@@ -1596,9 +1606,16 @@
 
     const DEFAULT_ACCENT = DEFAULT_OVERLAY.accent && DEFAULT_OVERLAY.accent.trim()
       ? DEFAULT_OVERLAY.accent.trim()
-      : '#ef4444';
-    const ACCENT_FALLBACK_HEX = parseHexForPicker(DEFAULT_ACCENT) || '#ef4444';
+      : '#38bdf8';
+    const DEFAULT_ACCENT_SECONDARY = DEFAULT_OVERLAY.accentSecondary && DEFAULT_OVERLAY.accentSecondary.trim()
+      ? DEFAULT_OVERLAY.accentSecondary.trim()
+      : '';
+    const ACCENT_FALLBACK_HEX = parseHexForPicker(DEFAULT_ACCENT) || '#38bdf8';
+    const ACCENT_SECONDARY_FALLBACK_HEX = DEFAULT_ACCENT_SECONDARY
+      ? (parseHexForPicker(DEFAULT_ACCENT_SECONDARY) || ACCENT_FALLBACK_HEX)
+      : ACCENT_FALLBACK_HEX;
     const ACCENT_HINT_DEFAULT = 'Accepts hex (#ff0000), rgb(a), hsl(a), or named colours.';
+    const ACCENT_SECONDARY_HINT_DEFAULT = 'Optional second highlight used by Duotone Fusion and blended gradients.';
     const PRESET_NAME_HINT = 'Preset names can be up to 80 characters.';
 
     const DEFAULT_STATE = {
@@ -1705,6 +1722,10 @@
       overlayAccentPicker: document.getElementById('overlayAccentPicker'),
       overlayAccentGroup: document.getElementById('overlayAccentGroup'),
       overlayAccentHint: document.getElementById('overlayAccentHint'),
+      overlayAccentSecondary: document.getElementById('overlayAccentSecondary'),
+      overlayAccentSecondaryPicker: document.getElementById('overlayAccentSecondaryPicker'),
+      overlayAccentSecondaryGroup: document.getElementById('overlayAccentSecondaryGroup'),
+      overlayAccentSecondaryHint: document.getElementById('overlayAccentSecondaryHint'),
       highlightWords: document.getElementById('highlightWords'),
       scaleRange: document.getElementById('scaleRange'),
       scaleNumber: document.getElementById('scaleNumber'),
@@ -2500,6 +2521,9 @@
       params.set('server', serverBase());
       params.set('label', overlayPrefs.label || 'LIVE');
       if (overlayPrefs.accent && isSafeColour(overlayPrefs.accent)) params.set('accent', overlayPrefs.accent);
+      if (overlayPrefs.accentSecondary && isSafeColour(overlayPrefs.accentSecondary)) {
+        params.set('accentSecondary', overlayPrefs.accentSecondary);
+      }
       const highlights = (overlayPrefs.highlight || '')
         .split(',')
         .map(s => s.trim())
@@ -2673,6 +2697,13 @@
       if (el.overlayAccentPicker) {
         el.overlayAccentPicker.value = parseHexForPicker(accent) || ACCENT_FALLBACK_HEX;
       }
+      const secondary = overlayPrefs.accentSecondary || '';
+      if (el.overlayAccentSecondary) {
+        el.overlayAccentSecondary.value = secondary;
+      }
+      if (el.overlayAccentSecondaryPicker) {
+        el.overlayAccentSecondaryPicker.value = parseHexForPicker(secondary) || ACCENT_SECONDARY_FALLBACK_HEX;
+      }
     }
 
     function setAccentError(message) {
@@ -2683,6 +2714,17 @@
       if (el.overlayAccentHint) {
         el.overlayAccentHint.textContent = hasError ? message : ACCENT_HINT_DEFAULT;
         el.overlayAccentHint.classList.toggle('is-error', hasError);
+      }
+    }
+
+    function setAccentSecondaryError(message) {
+      const hasError = Boolean(message);
+      if (el.overlayAccentSecondaryGroup) {
+        el.overlayAccentSecondaryGroup.classList.toggle('has-error', hasError);
+      }
+      if (el.overlayAccentSecondaryHint) {
+        el.overlayAccentSecondaryHint.textContent = hasError ? message : ACCENT_SECONDARY_HINT_DEFAULT;
+        el.overlayAccentSecondaryHint.classList.toggle('is-error', hasError);
       }
     }
 
@@ -2700,12 +2742,18 @@
       } else {
         el.popupPreview.style.removeProperty('--preview-accent');
       }
+      if (overlayPrefs.accentSecondary && isSafeColour(overlayPrefs.accentSecondary)) {
+        el.popupPreview.style.setProperty('--preview-accent-secondary', overlayPrefs.accentSecondary);
+      } else {
+        el.popupPreview.style.removeProperty('--preview-accent-secondary');
+      }
     }
 
     function renderOverlayControls() {
       el.overlayLabel.value = overlayPrefs.label;
       updateAccentInputsFromPrefs();
       setAccentError('');
+      setAccentSecondaryError('');
       el.highlightWords.value = overlayPrefs.highlight;
       el.scaleRange.value = overlayPrefs.scale;
       el.scaleNumber.value = overlayPrefs.scale;
@@ -3668,6 +3716,7 @@
       const payload = {
         label: overlayPrefs.label,
         accent: overlayPrefs.accent,
+        accentSecondary: overlayPrefs.accentSecondary,
         highlight: overlayPrefs.highlight,
         scale: overlayPrefs.scale,
         popupScale: overlayPrefs.popupScale,
@@ -4433,12 +4482,12 @@
         overlayPrefs.accent = '';
         updateAccentInputsFromPrefs();
         setAccentError('');
+        applyPreviewTheme();
         if (changed) {
           updateOverlayChip();
           saveLocal();
           queueOverlaySave();
         }
-        applyPreviewTheme();
         return;
       }
       if (!isSafeColour(trimmed)) {
@@ -4454,6 +4503,45 @@
       setAccentError('');
       const changed = trimmed !== overlayPrefs.accent;
       overlayPrefs.accent = trimmed;
+      updateAccentInputsFromPrefs();
+      if (changed) {
+        updateOverlayChip();
+        saveLocal();
+        queueOverlaySave();
+      }
+      applyPreviewTheme();
+    }
+
+    function commitAccentSecondaryInput(nextValue) {
+      if (!el.overlayAccentSecondary) return;
+      const rawValue = typeof nextValue === 'string' ? nextValue : el.overlayAccentSecondary.value;
+      const trimmed = rawValue.trim();
+      if (!trimmed) {
+        const changed = overlayPrefs.accentSecondary !== '';
+        overlayPrefs.accentSecondary = '';
+        updateAccentInputsFromPrefs();
+        setAccentSecondaryError('');
+        applyPreviewTheme();
+        if (changed) {
+          updateOverlayChip();
+          saveLocal();
+          queueOverlaySave();
+        }
+        return;
+      }
+      if (!isSafeColour(trimmed)) {
+        if (el.overlayAccentSecondary) {
+          el.overlayAccentSecondary.value = trimmed;
+        }
+        setAccentSecondaryError('Enter a valid CSS colour value or clear the field.');
+        if (el.overlayAccentSecondaryPicker) {
+          el.overlayAccentSecondaryPicker.value = parseHexForPicker(overlayPrefs.accentSecondary) || ACCENT_SECONDARY_FALLBACK_HEX;
+        }
+        return;
+      }
+      setAccentSecondaryError('');
+      const changed = trimmed !== overlayPrefs.accentSecondary;
+      overlayPrefs.accentSecondary = trimmed;
       updateAccentInputsFromPrefs();
       if (changed) {
         updateOverlayChip();
@@ -4486,6 +4574,34 @@
       el.overlayAccentPicker.addEventListener('input', event => {
         setAccentError('');
         commitAccentInput(event.target.value);
+      });
+    }
+
+    if (el.overlayAccentSecondary) {
+      el.overlayAccentSecondary.addEventListener('input', () => {
+        const current = el.overlayAccentSecondary.value.trim();
+        if (!current) {
+          setAccentSecondaryError('');
+          if (el.overlayAccentSecondaryPicker) {
+            el.overlayAccentSecondaryPicker.value = overlayPrefs.accent
+              ? (parseHexForPicker(overlayPrefs.accent) || ACCENT_SECONDARY_FALLBACK_HEX)
+              : ACCENT_SECONDARY_FALLBACK_HEX;
+          }
+          return;
+        }
+        setAccentSecondaryError('');
+        const hex = parseHexForPicker(current);
+        if (hex && el.overlayAccentSecondaryPicker) {
+          el.overlayAccentSecondaryPicker.value = hex;
+        }
+      });
+      el.overlayAccentSecondary.addEventListener('change', () => commitAccentSecondaryInput());
+      el.overlayAccentSecondary.addEventListener('blur', () => commitAccentSecondaryInput());
+    }
+    if (el.overlayAccentSecondaryPicker) {
+      el.overlayAccentSecondaryPicker.addEventListener('input', event => {
+        setAccentSecondaryError('');
+        commitAccentSecondaryInput(event.target.value);
       });
     }
 

--- a/public/js/client-normalisers.js
+++ b/public/js/client-normalisers.js
@@ -13,13 +13,11 @@
   }
 })(typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this, function (sharedUtils = {}, sharedConfig = {}) {
   const FALLBACK_THEMES = [
-    'holographic',
-    'liquid-glass',
-    'neural',
-    'quantum',
-    'crystalline',
-    'neon-noir',
-    'monotone'
+    'midnight-glass',
+    'aurora-night',
+    'nexus-grid',
+    'zen-flow',
+    'duotone-fusion'
   ];
 
   const MAX_MESSAGES = 50;
@@ -46,7 +44,8 @@
 
   const defaultOverlay = Object.freeze({
     label: 'LIVE',
-    accent: '#ef4444',
+    accent: '#38bdf8',
+    accentSecondary: '#f472b6',
     highlight: defaultHighlightString,
     scale: 1.75,
     popupScale: 1,
@@ -54,7 +53,7 @@
     mode: 'auto',
     accentAnim: true,
     sparkle: true,
-    theme: 'monotone',
+    theme: 'midnight-glass',
     ...(sharedConfig.DEFAULT_OVERLAY || {})
   });
 
@@ -233,6 +232,15 @@
         result.accent = '';
       } else if (trimmed.length <= 64 && isSafeColour(trimmed)) {
         result.accent = trimmed;
+      }
+    }
+
+    if (typeof data.accentSecondary === 'string') {
+      const trimmedSecondary = data.accentSecondary.trim();
+      if (!trimmedSecondary) {
+        result.accentSecondary = '';
+      } else if (trimmedSecondary.length <= 64 && isSafeColour(trimmedSecondary)) {
+        result.accentSecondary = trimmedSecondary;
       }
     }
 

--- a/public/js/scene-normaliser.js
+++ b/public/js/scene-normaliser.js
@@ -10,6 +10,7 @@
   const DEFAULT_OVERLAY_KEYS = [
     'label',
     'accent',
+    'accentSecondary',
     'highlight',
     'scale',
     'popupScale',

--- a/public/js/shared-config.js
+++ b/public/js/shared-config.js
@@ -20,7 +20,8 @@
 
   const DEFAULT_OVERLAY = Object.freeze({
     label: 'LIVE',
-    accent: '#ef4444',
+    accent: '#38bdf8',
+    accentSecondary: '#f472b6',
     highlight: DEFAULT_HIGHLIGHT_STRING,
     scale: 1.75,
     popupScale: 1,
@@ -28,7 +29,7 @@
     mode: 'auto',
     accentAnim: true,
     sparkle: true,
-    theme: 'monotone'
+    theme: 'midnight-glass'
   });
 
   const DEFAULT_POPUP = Object.freeze({

--- a/public/js/shared-utils.js
+++ b/public/js/shared-utils.js
@@ -20,13 +20,11 @@
   ]);
 
   const OVERLAY_THEMES = [
-    'holographic',
-    'liquid-glass',
-    'neural',
-    'quantum',
-    'crystalline',
-    'neon-noir',
-    'monotone'
+    'midnight-glass',
+    'aurora-night',
+    'nexus-grid',
+    'zen-flow',
+    'duotone-fusion'
   ];
 
   function clampNumber(value, min, max, fallback, precision) {

--- a/public/output.html
+++ b/public/output.html
@@ -9,6 +9,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/SplitText.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrambleTextPlugin.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/6.5.8/pixi.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/three.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <link rel="stylesheet" href="css/themes.css">
   <style>
     :root {
@@ -18,13 +21,15 @@
       --label-width: calc(100px * var(--ui-scale));
       --padding-x: var(--space-lg);
       --divider-height: calc(var(--space-sm) * 1.75);
-      --accent: #ef4444;
-      --accent-bright: color-mix(in srgb, var(--accent) 80%, #f8f9ff 20%);
+      --accent: #38bdf8;
+      --accent-secondary: #f472b6;
+      --accent-bright: color-mix(in srgb, var(--accent) 78%, #f6fbff 22%);
+      --accent-secondary-bright: color-mix(in srgb, var(--accent-secondary, var(--accent)) 75%, #f5f1ff 25%);
       --accent-soft: color-mix(in srgb, var(--accent) 16%, transparent);
-      --accent-glow: color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.4));
-      --accent-muted: color-mix(in srgb, var(--accent) 55%, rgba(14, 16, 24, 0.7));
-      --accent-duo: color-mix(in srgb, var(--accent) 60%, #1c1e27 40%);
-      --accent-contrast: color-mix(in srgb, var(--accent) 56%, #0d0f16 44%);
+      --accent-glow: color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.42));
+      --accent-muted: color-mix(in srgb, var(--accent) 45%, rgba(14, 18, 30, 0.75));
+      --accent-duo: color-mix(in srgb, var(--accent) 55%, var(--accent-secondary, var(--accent)) 45%);
+      --accent-contrast: color-mix(in srgb, var(--accent) 52%, #0b0f1a 48%);
       --surface-a: rgba(14, 16, 24, 0.94);
       --surface-b: rgba(6, 8, 14, 0.92);
       --surface-border: rgba(255, 255, 255, 0.12);
@@ -47,20 +52,26 @@
       --ticker-divider-color: rgba(255, 255, 255, 0.32);
       --ticker-accent-overlay:
         linear-gradient(155deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0) 62%),
-        linear-gradient(150deg, var(--accent-bright), var(--accent-muted));
-      --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.3));
-      --ticker-accent-glow: 0 0 12px color-mix(in srgb, var(--accent) 24%, rgba(255, 255, 255, 0.22));
-      --ticker-accent-animation: holographicShift 20s var(--ease-premium) infinite;
+        linear-gradient(140deg,
+          color-mix(in srgb, var(--accent-bright) 80%, rgba(255, 255, 255, 0.2) 20%),
+          color-mix(in srgb, var(--accent-secondary, var(--accent)) 58%, rgba(8, 12, 24, 0.82) 42%)
+        );
+      --ticker-accent-border: 1px solid color-mix(in srgb, var(--accent) 45%, rgba(255, 255, 255, 0.28));
+      --ticker-accent-glow: 0 0 18px color-mix(in srgb, var(--accent) 22%, rgba(255, 255, 255, 0.26));
+      --ticker-accent-animation: midnightGlassSweep 18s var(--ease-premium) infinite;
       --popup-surface-a: color-mix(in srgb, var(--ticker-surface-a) 92%, rgba(255, 255, 255, 0.02));
       --popup-surface-b: color-mix(in srgb, var(--ticker-surface-b) 92%, rgba(0, 0, 0, 0.08));
       --popup-border-color: color-mix(in srgb, var(--ticker-border) 85%, rgba(255, 255, 255, 0.12));
       --popup-shadow: var(--ticker-shadow);
       --popup-text-color: rgba(248, 250, 255, 0.96);
       --popup-divider-color: color-mix(in srgb, var(--ticker-divider-color) 78%, rgba(255, 255, 255, 0.12));
-      --popup-countdown-color: color-mix(in srgb, rgba(240, 242, 248, 0.9) 85%, var(--accent) 15%);
-      --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.52) 75%, var(--accent) 25%);
+      --popup-countdown-color: color-mix(in srgb, rgba(240, 242, 248, 0.9) 82%, var(--accent) 18%);
+      --popup-countdown-dot: color-mix(in srgb, rgba(255, 255, 255, 0.52) 70%, var(--accent-secondary, var(--accent)) 30%);
       --popup-accent-strip:
-        linear-gradient(165deg, var(--accent), color-mix(in srgb, var(--accent) 32%, rgba(255, 255, 255, 0.45)));
+        linear-gradient(165deg,
+          color-mix(in srgb, var(--accent) 78%, rgba(255, 255, 255, 0.2)),
+          color-mix(in srgb, var(--accent-secondary, var(--accent)) 52%, rgba(255, 255, 255, 0.08))
+        );
       --popup-sheen: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0) 65%);
     }
 
@@ -112,6 +123,26 @@
       will-change: transform, opacity, filter;
       contain: layout style paint;
       z-index: 1000;
+    }
+
+    .ticker-visuals {
+      position: absolute;
+      inset: 0;
+      overflow: hidden;
+      pointer-events: none;
+      z-index: 0;
+      mix-blend-mode: normal;
+    }
+
+    .ticker-visuals canvas,
+    .ticker-visuals video,
+    .ticker-visuals svg,
+    .ticker-visuals div {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
     }
 
     .ticker.top {
@@ -205,6 +236,7 @@
       top: 0;
       bottom: 0;
       overflow: hidden;
+      z-index: 2;
     }
 
     .ticker-content {
@@ -650,6 +682,7 @@
   </div>
 
   <div class="ticker" id="ticker">
+    <div class="ticker-visuals" id="tickerVisuals"></div>
     <div class="ticker-label" id="tickerLabel">LIVE</div>
     <div class="ticker-track" id="tickerTrack">
       <div class="ticker-content" id="tickerContent"></div>
@@ -694,11 +727,12 @@
     const MAX_SLATE_TEXT_LENGTH = 200;
     const MAX_SLATE_NOTES = 6;
     const HIDE_TRANSITION_FALLBACK_MS = 700;
-    const THEME_CLASSNAMES = (Array.isArray(OVERLAY_THEMES) ? OVERLAY_THEMES : ['holographic', 'liquid-glass', 'neural', 'quantum', 'crystalline', 'neon-noir', 'monotone']).map(theme => `ticker--${theme}`);
+    const THEME_CLASSNAMES = (Array.isArray(OVERLAY_THEMES) ? OVERLAY_THEMES : ['midnight-glass', 'aurora-night', 'nexus-grid', 'zen-flow', 'duotone-fusion']).map(theme => `ticker--${theme}`);
 
     const DEFAULT_OVERLAY = {
       label: 'LIVE',
-      accent: '#ef4444',
+      accent: '#38bdf8',
+      accentSecondary: '#f472b6',
       highlight: DEFAULT_HIGHLIGHT_STRING,
       scale: 1.75,
       popupScale: 1,
@@ -706,7 +740,7 @@
       mode: 'auto',
       accentAnim: true,
       sparkle: true,
-      theme: 'monotone',
+      theme: 'midnight-glass',
       ...(sharedConfig.DEFAULT_OVERLAY || {})
     };
     if (!DEFAULT_OVERLAY.highlight) {
@@ -1466,6 +1500,824 @@
       return animator;
     }
 
+    function resolveColorString(value, fallback) {
+      return value && typeof value === 'string' && value.trim() ? value.trim() : fallback;
+    }
+
+    let colorParserElement = null;
+    function ensureColorParserElement() {
+      if (colorParserElement || typeof document === 'undefined') return colorParserElement;
+      colorParserElement = document.createElement('span');
+      colorParserElement.style.position = 'absolute';
+      colorParserElement.style.opacity = '0';
+      colorParserElement.style.pointerEvents = 'none';
+      colorParserElement.style.left = '-9999px';
+      colorParserElement.style.top = '-9999px';
+      if (document.body) {
+        document.body.appendChild(colorParserElement);
+      }
+      return colorParserElement;
+    }
+
+    function colorStringToRgbArray(color, fallback = '#ffffff') {
+      const el = ensureColorParserElement();
+      if (!el) return [1, 1, 1, 1];
+      const target = resolveColorString(color, fallback);
+      el.style.color = target;
+      const computed = getComputedStyle(el).color || 'rgb(255, 255, 255)';
+      const match = computed.match(/rgba?\((\d+(?:\.\d+)?),\s*(\d+(?:\.\d+)?),\s*(\d+(?:\.\d+)?)(?:,\s*(\d+(?:\.\d+)?))?\)/i);
+      if (!match) {
+        return [1, 1, 1, 1];
+      }
+      const r = Math.min(255, Math.max(0, parseFloat(match[1] || '0')));
+      const g = Math.min(255, Math.max(0, parseFloat(match[2] || '0')));
+      const b = Math.min(255, Math.max(0, parseFloat(match[3] || '0')));
+      const a = match[4] !== undefined ? Math.min(1, Math.max(0, parseFloat(match[4]))) : 1;
+      return [r / 255, g / 255, b / 255, a];
+    }
+
+    function colorStringToNumber(color, fallback = '#ffffff') {
+      const rgb = colorStringToRgbArray(color, fallback);
+      const r = Math.round(rgb[0] * 255);
+      const g = Math.round(rgb[1] * 255);
+      const b = Math.round(rgb[2] * 255);
+      return ((r & 0xff) << 16) | ((g & 0xff) << 8) | (b & 0xff);
+    }
+
+    function createMidnightPalette(primary, secondary) {
+      const base = resolveColorString(primary, '#38bdf8');
+      const alt = resolveColorString(secondary, base);
+      return [colorStringToNumber(base), colorStringToNumber(alt)];
+    }
+
+    class MidnightGlassEngine {
+      constructor(container, options = {}) {
+        this.name = 'midnight-glass';
+        this.container = container;
+        this.reducedMotion = !!options.reducedMotion;
+        this.app = null;
+        this.orbs = [];
+        this.palette = createMidnightPalette(options.accent, options.accentSecondary);
+        if (!container || typeof PIXI === 'undefined') return;
+        try {
+          this.app = new PIXI.Application({
+            width: container.clientWidth || 1,
+            height: container.clientHeight || 1,
+            backgroundAlpha: 0,
+            antialias: true,
+            autoStart: !this.reducedMotion,
+            resolution: window.devicePixelRatio || 1
+          });
+        } catch (err) {
+          console.warn('[ticker] failed to initialise PixiJS background', err);
+          this.app = null;
+          return;
+        }
+        this.app.renderer.view.style.width = '100%';
+        this.app.renderer.view.style.height = '100%';
+        this.app.renderer.view.style.pointerEvents = 'none';
+        container.appendChild(this.app.view);
+        this.blurFilter = new PIXI.filters.BlurFilter();
+        this.blurFilter.blur = 24;
+        this.blurFilter.quality = 4;
+        this.app.stage.filters = [this.blurFilter];
+        this.createOrbs();
+        this.app.ticker.add(this.tick, this);
+        if (this.reducedMotion) {
+          this.app.ticker.stop();
+        }
+      }
+
+      createOrbs() {
+        if (!this.app) return;
+        const width = this.app.renderer.width;
+        const height = this.app.renderer.height;
+        const count = Math.max(10, Math.round((width + height) / 160));
+        this.orbs = [];
+        for (let i = 0; i < count; i++) {
+          const graphic = new PIXI.Graphics();
+          const radius = this.randomBetween(70, 160);
+          const color = this.palette[i % this.palette.length];
+          graphic.beginFill(color, 0.12);
+          graphic.drawCircle(0, 0, radius);
+          graphic.endFill();
+          graphic.x = Math.random() * width;
+          graphic.y = Math.random() * height;
+          graphic.alpha = 0.85;
+          this.app.stage.addChild(graphic);
+          this.orbs.push({
+            sprite: graphic,
+            radius,
+            vx: (Math.random() - 0.5) * 0.25,
+            vy: (Math.random() - 0.5) * 0.25,
+            drift: 0.4 + Math.random() * 0.6
+          });
+        }
+      }
+
+      randomBetween(min, max) {
+        return min + Math.random() * (max - min);
+      }
+
+      tick(delta) {
+        if (!this.app || this.reducedMotion) return;
+        const width = this.app.renderer.width;
+        const height = this.app.renderer.height;
+        for (const orb of this.orbs) {
+          orb.sprite.x += orb.vx * delta * orb.drift;
+          orb.sprite.y += orb.vy * delta * orb.drift;
+          if (orb.sprite.x < -orb.radius) orb.sprite.x = width + orb.radius;
+          if (orb.sprite.x > width + orb.radius) orb.sprite.x = -orb.radius;
+          if (orb.sprite.y < -orb.radius) orb.sprite.y = height + orb.radius;
+          if (orb.sprite.y > height + orb.radius) orb.sprite.y = -orb.radius;
+        }
+      }
+
+      updateColors(colors = {}) {
+        this.palette = createMidnightPalette(colors.accent, colors.accentSecondary);
+        this.orbs.forEach((orb, index) => {
+          const color = this.palette[index % this.palette.length];
+          orb.sprite.clear();
+          orb.sprite.beginFill(color, 0.12);
+          orb.sprite.drawCircle(0, 0, orb.radius);
+          orb.sprite.endFill();
+        });
+      }
+
+      setReducedMotion(flag) {
+        this.reducedMotion = !!flag;
+        if (!this.app) return;
+        if (this.reducedMotion) {
+          this.app.ticker.stop();
+        } else {
+          this.app.ticker.start();
+        }
+      }
+
+      resize() {
+        if (!this.app || !this.container) return;
+        const width = this.container.clientWidth || 1;
+        const height = this.container.clientHeight || 1;
+        this.app.renderer.resize(width, height);
+        this.createOrbs();
+        if (this.reducedMotion) {
+          this.app.render();
+        }
+      }
+
+      destroy() {
+        if (this.app) {
+          this.app.ticker.remove(this.tick, this);
+          this.app.destroy(true, { children: true, texture: true, baseTexture: true });
+          this.app = null;
+        }
+        this.orbs = [];
+      }
+    }
+
+    class AuroraNightEngine {
+      constructor(container, options = {}) {
+        this.name = 'aurora-night';
+        this.container = container;
+        this.reducedMotion = !!options.reducedMotion;
+        this.renderer = null;
+        this.scene = null;
+        this.camera = null;
+        this.mesh = null;
+        this.uniforms = null;
+        this.render = this.render.bind(this);
+        if (!container || typeof THREE === 'undefined') return;
+        try {
+          this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+        } catch (err) {
+          console.warn('[ticker] failed to initialise WebGL renderer', err);
+          this.renderer = null;
+          return;
+        }
+        this.renderer.setPixelRatio(window.devicePixelRatio || 1);
+        this.renderer.setSize(container.clientWidth || 1, container.clientHeight || 1);
+        this.renderer.domElement.style.width = '100%';
+        this.renderer.domElement.style.height = '100%';
+        this.renderer.domElement.style.pointerEvents = 'none';
+        container.appendChild(this.renderer.domElement);
+
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+        this.uniforms = {
+          u_time: { value: 0 },
+          u_colorA: { value: new THREE.Color(resolveColorString(options.accent, '#38bdf8')) },
+          u_colorB: { value: new THREE.Color(resolveColorString(options.accentSecondary, options.accent || '#f472b6')) }
+        };
+        const geometry = new THREE.PlaneGeometry(2, 2);
+        const vertexShader = `varying vec2 vUv; void main() { vUv = uv; gl_Position = vec4(position.xy, 0.0, 1.0); }`;
+        const fragmentShader = `precision highp float; varying vec2 vUv; uniform float u_time; uniform vec3 u_colorA; uniform vec3 u_colorB; float wave(vec2 uv, float shift) { return sin((uv.x * 6.2831) + shift + u_time * 0.3) * 0.35 + 0.5; } void main() { vec2 uv = vUv; float band1 = wave(uv * vec2(1.0, 1.6), 0.0); float band2 = wave(uv * vec2(1.2, 1.4), 1.57); float mixVal = clamp((band1 + band2) * 0.5, 0.0, 1.0); vec3 color = mix(u_colorB, u_colorA, mixVal); float alpha = smoothstep(0.0, 0.35, mixVal) * 0.7; gl_FragColor = vec4(color, alpha); }`;
+        const material = new THREE.ShaderMaterial({
+          uniforms: this.uniforms,
+          vertexShader,
+          fragmentShader,
+          transparent: true,
+          depthTest: false,
+          depthWrite: false
+        });
+        this.mesh = new THREE.Mesh(geometry, material);
+        this.scene.add(this.mesh);
+        if (!this.reducedMotion) {
+          this.renderer.setAnimationLoop(this.render);
+        } else {
+          this.render(performance.now());
+        }
+      }
+
+      render(time = performance.now()) {
+        if (!this.renderer || !this.uniforms) return;
+        this.uniforms.u_time.value = time * 0.001;
+        this.renderer.render(this.scene, this.camera);
+      }
+
+      updateColors(colors = {}) {
+        if (!this.uniforms) return;
+        const primary = resolveColorString(colors.accent, '#38bdf8');
+        const secondary = resolveColorString(colors.accentSecondary, primary);
+        try {
+          this.uniforms.u_colorA.value.set(primary);
+          this.uniforms.u_colorB.value.set(secondary);
+        } catch (err) {
+          // ignore colour conversion errors
+        }
+        if (this.reducedMotion) {
+          this.render(performance.now());
+        }
+      }
+
+      setReducedMotion(flag) {
+        this.reducedMotion = !!flag;
+        if (!this.renderer) return;
+        if (this.reducedMotion) {
+          this.renderer.setAnimationLoop(null);
+          this.render(performance.now());
+        } else {
+          this.renderer.setAnimationLoop(this.render);
+        }
+      }
+
+      resize() {
+        if (!this.renderer || !this.container) return;
+        const width = this.container.clientWidth || 1;
+        const height = this.container.clientHeight || 1;
+        this.renderer.setSize(width, height);
+        if (this.reducedMotion) {
+          this.render(performance.now());
+        }
+      }
+
+      destroy() {
+        if (this.renderer) {
+          this.renderer.setAnimationLoop(null);
+          this.renderer.dispose();
+          if (this.renderer.domElement && this.renderer.domElement.parentNode) {
+            this.renderer.domElement.parentNode.removeChild(this.renderer.domElement);
+          }
+        }
+        this.renderer = null;
+        this.scene = null;
+        this.mesh = null;
+        this.uniforms = null;
+      }
+    }
+
+    class NexusGridEngine {
+      constructor(container, options = {}) {
+        this.name = 'nexus-grid';
+        this.container = container;
+        this.reducedMotion = !!options.reducedMotion;
+        this.accent = resolveColorString(options.accent, '#38bdf8');
+        this.accentSecondary = resolveColorString(options.accentSecondary, this.accent);
+        this.canvas = null;
+        this.ctx = null;
+        this.nodes = [];
+        this.animFrame = null;
+        if (!container) return;
+        this.canvas = document.createElement('canvas');
+        this.canvas.width = container.clientWidth || 1;
+        this.canvas.height = container.clientHeight || 1;
+        this.canvas.style.width = '100%';
+        this.canvas.style.height = '100%';
+        this.canvas.style.pointerEvents = 'none';
+        container.appendChild(this.canvas);
+        this.ctx = this.canvas.getContext('2d');
+        this.initNodes();
+        if (!this.reducedMotion) {
+          this.animate();
+        } else {
+          this.draw();
+        }
+      }
+
+      initNodes() {
+        if (!this.canvas) return;
+        const width = this.canvas.width;
+        const height = this.canvas.height;
+        const count = Math.max(18, Math.round((width + height) / 80));
+        this.nodes = [];
+        for (let i = 0; i < count; i++) {
+          this.nodes.push({
+            x: Math.random() * width,
+            y: Math.random() * height,
+            vx: (Math.random() - 0.5) * 0.35,
+            vy: (Math.random() - 0.5) * 0.35,
+            pulse: Math.random() * Math.PI * 2
+          });
+        }
+      }
+
+      animate() {
+        if (this.reducedMotion) return;
+        this.draw();
+        this.animFrame = requestAnimationFrame(() => this.animate());
+      }
+
+      draw() {
+        if (!this.ctx || !this.canvas) return;
+        const ctx = this.ctx;
+        const width = this.canvas.width;
+        const height = this.canvas.height;
+        ctx.clearRect(0, 0, width, height);
+        ctx.fillStyle = 'rgba(8, 12, 20, 0.45)';
+        ctx.fillRect(0, 0, width, height);
+        const primary = colorStringToRgbArray(this.accent);
+        const secondary = colorStringToRgbArray(this.accentSecondary);
+        const strokeStyle = `rgba(${Math.round(primary[0] * 255)}, ${Math.round(primary[1] * 255)}, ${Math.round(primary[2] * 255)}, 0.32)`;
+        const secondaryStroke = `rgba(${Math.round(secondary[0] * 255)}, ${Math.round(secondary[1] * 255)}, ${Math.round(secondary[2] * 255)}, 0.24)`;
+        const nodeFill = `rgba(${Math.round(primary[0] * 255)}, ${Math.round(primary[1] * 255)}, ${Math.round(primary[2] * 255)}, 0.55)`;
+        const nodeFillSecondary = `rgba(${Math.round(secondary[0] * 255)}, ${Math.round(secondary[1] * 255)}, ${Math.round(secondary[2] * 255)}, 0.45)`;
+        for (let i = 0; i < this.nodes.length; i++) {
+          const node = this.nodes[i];
+          if (!this.reducedMotion) {
+            node.x += node.vx;
+            node.y += node.vy;
+            node.pulse += 0.01;
+            if (node.x < 0 || node.x > width) node.vx *= -1;
+            if (node.y < 0 || node.y > height) node.vy *= -1;
+          }
+          const radius = 2.4 + Math.sin(node.pulse) * 1.6;
+          ctx.beginPath();
+          ctx.fillStyle = i % 2 === 0 ? nodeFill : nodeFillSecondary;
+          ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
+          ctx.fill();
+          for (let j = i + 1; j < this.nodes.length; j++) {
+            const other = this.nodes[j];
+            const dx = node.x - other.x;
+            const dy = node.y - other.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist < Math.min(width, height) * 0.25) {
+              const alpha = 0.35 - (dist / (Math.min(width, height) * 0.25)) * 0.35;
+              ctx.strokeStyle = j % 2 === 0 ? strokeStyle : secondaryStroke;
+              ctx.globalAlpha = Math.max(0.08, alpha);
+              ctx.beginPath();
+              ctx.moveTo(node.x, node.y);
+              ctx.lineTo(other.x, other.y);
+              ctx.stroke();
+              ctx.globalAlpha = 1;
+            }
+          }
+        }
+      }
+
+      updateColors(colors = {}) {
+        this.accent = resolveColorString(colors.accent, this.accent);
+        this.accentSecondary = resolveColorString(colors.accentSecondary, this.accentSecondary);
+        if (this.reducedMotion) {
+          this.draw();
+        }
+      }
+
+      setReducedMotion(flag) {
+        this.reducedMotion = !!flag;
+        if (this.reducedMotion) {
+          if (this.animFrame) {
+            cancelAnimationFrame(this.animFrame);
+            this.animFrame = null;
+          }
+          this.draw();
+        } else {
+          this.animate();
+        }
+      }
+
+      resize() {
+        if (!this.canvas || !this.container) return;
+        const width = this.container.clientWidth || 1;
+        const height = this.container.clientHeight || 1;
+        this.canvas.width = width;
+        this.canvas.height = height;
+        this.initNodes();
+        if (this.reducedMotion) {
+          this.draw();
+        }
+      }
+
+      destroy() {
+        if (this.animFrame) {
+          cancelAnimationFrame(this.animFrame);
+          this.animFrame = null;
+        }
+        if (this.canvas && this.canvas.parentNode) {
+          this.canvas.parentNode.removeChild(this.canvas);
+        }
+        this.canvas = null;
+        this.ctx = null;
+        this.nodes = [];
+      }
+    }
+
+    const ZEN_FLOW_BASE_ANIMATION = {
+      v: '5.7.6',
+      fr: 60,
+      ip: 0,
+      op: 360,
+      w: 800,
+      h: 450,
+      nm: 'Zen Flow',
+      ddd: 0,
+      assets: [],
+      layers: [
+        {
+          ddd: 0,
+          ind: 1,
+          ty: 4,
+          nm: 'Blob A',
+          ks: {
+            o: { a: 0, k: 60 },
+            r: { a: 0, k: 0 },
+            p: {
+              a: 1,
+              k: [
+                { t: 0, s: [420, 240, 0], to: [30, -10, 0], ti: [-30, 10, 0] },
+                { t: 180, s: [380, 210, 0], to: [-30, 10, 0], ti: [30, -10, 0] },
+                { t: 360, s: [420, 240, 0] }
+              ]
+            },
+            a: { a: 0, k: [0, 0, 0] },
+            s: {
+              a: 1,
+              k: [
+                { t: 0, s: [115, 125, 100] },
+                { t: 180, s: [135, 95, 100] },
+                { t: 360, s: [115, 125, 100] }
+              ]
+            }
+          },
+          shapes: [
+            {
+              ty: 'gr',
+              nm: 'Blob A Group',
+              it: [
+                {
+                  ty: 'el',
+                  p: { a: 0, k: [0, 0] },
+                  s: { a: 0, k: [360, 360] },
+                  d: 1,
+                  nm: 'Ellipse Path 1',
+                  mn: 'ADBE Vector Shape - Ellipse',
+                  hd: false
+                },
+                {
+                  ty: 'fl',
+                  c: { a: 0, k: [0.2, 0.6, 0.9, 1] },
+                  o: { a: 0, k: 100 },
+                  r: 1,
+                  nm: 'Fill 1',
+                  mn: 'ADBE Vector Graphic - Fill',
+                  hd: false
+                },
+                {
+                  ty: 'tr',
+                  p: { a: 0, k: [0, 0] },
+                  a: { a: 0, k: [0, 0] },
+                  s: { a: 0, k: [100, 100] },
+                  r: { a: 0, k: 0 },
+                  o: { a: 0, k: 100 },
+                  sk: { a: 0, k: 0 },
+                  sa: { a: 0, k: 0 },
+                  nm: 'Transform'
+                }
+              ],
+              np: 2,
+              cix: 2,
+              bm: 0,
+              ix: 1,
+              mn: 'ADBE Vector Group',
+              hd: false
+            }
+          ],
+          ip: 0,
+          op: 360,
+          st: 0,
+          bm: 0
+        },
+        {
+          ddd: 0,
+          ind: 2,
+          ty: 4,
+          nm: 'Blob B',
+          ks: {
+            o: { a: 0, k: 48 },
+            r: { a: 0, k: 0 },
+            p: {
+              a: 1,
+              k: [
+                { t: 0, s: [360, 230, 0], to: [-20, 15, 0], ti: [20, -15, 0] },
+                { t: 180, s: [410, 270, 0], to: [20, -15, 0], ti: [-20, 15, 0] },
+                { t: 360, s: [360, 230, 0] }
+              ]
+            },
+            a: { a: 0, k: [0, 0, 0] },
+            s: {
+              a: 1,
+              k: [
+                { t: 0, s: [95, 105, 100] },
+                { t: 180, s: [120, 90, 100] },
+                { t: 360, s: [95, 105, 100] }
+              ]
+            }
+          },
+          shapes: [
+            {
+              ty: 'gr',
+              nm: 'Blob B Group',
+              it: [
+                {
+                  ty: 'el',
+                  p: { a: 0, k: [0, 0] },
+                  s: { a: 0, k: [300, 300] },
+                  d: 1,
+                  nm: 'Ellipse Path 1',
+                  mn: 'ADBE Vector Shape - Ellipse',
+                  hd: false
+                },
+                {
+                  ty: 'fl',
+                  c: { a: 0, k: [0.9, 0.35, 0.75, 1] },
+                  o: { a: 0, k: 100 },
+                  r: 1,
+                  nm: 'Fill 1',
+                  mn: 'ADBE Vector Graphic - Fill',
+                  hd: false
+                },
+                {
+                  ty: 'tr',
+                  p: { a: 0, k: [0, 0] },
+                  a: { a: 0, k: [0, 0] },
+                  s: { a: 0, k: [100, 100] },
+                  r: { a: 0, k: 0 },
+                  o: { a: 0, k: 100 },
+                  sk: { a: 0, k: 0 },
+                  sa: { a: 0, k: 0 },
+                  nm: 'Transform'
+                }
+              ],
+              np: 2,
+              cix: 2,
+              bm: 0,
+              ix: 1,
+              mn: 'ADBE Vector Group',
+              hd: false
+            }
+          ],
+          ip: 0,
+          op: 360,
+          st: 0,
+          bm: 0
+        }
+      ]
+    };
+
+    function buildZenFlowData(accent, accentSecondary) {
+      const data = JSON.parse(JSON.stringify(ZEN_FLOW_BASE_ANIMATION));
+      const primary = colorStringToRgbArray(accent, '#38bdf8');
+      const secondary = colorStringToRgbArray(accentSecondary, accent || '#f472b6');
+      if (data.layers[0]?.shapes?.[0]?.it?.[1]?.c) {
+        data.layers[0].shapes[0].it[1].c.k = primary;
+      }
+      if (data.layers[1]?.shapes?.[0]?.it?.[1]?.c) {
+        data.layers[1].shapes[0].it[1].c.k = secondary;
+      }
+      return data;
+    }
+
+    class ZenFlowEngine {
+      constructor(container, options = {}) {
+        this.name = 'zen-flow';
+        this.container = container;
+        this.reducedMotion = !!options.reducedMotion;
+        this.node = null;
+        this.animation = null;
+        this.accent = resolveColorString(options.accent, '#38bdf8');
+        this.accentSecondary = resolveColorString(options.accentSecondary, this.accent);
+        if (!container || typeof lottie === 'undefined') return;
+        this.node = document.createElement('div');
+        this.node.style.position = 'absolute';
+        this.node.style.inset = '-30%';
+        this.node.style.pointerEvents = 'none';
+        this.node.style.filter = 'blur(80px)';
+        this.node.style.mixBlendMode = 'screen';
+        container.appendChild(this.node);
+        this.loadAnimation();
+      }
+
+      loadAnimation() {
+        if (!this.node || typeof lottie === 'undefined') return;
+        if (this.animation) {
+          this.animation.destroy();
+          this.animation = null;
+        }
+        const data = buildZenFlowData(this.accent, this.accentSecondary);
+        this.animation = lottie.loadAnimation({
+          container: this.node,
+          renderer: 'svg',
+          loop: true,
+          autoplay: !this.reducedMotion,
+          animationData: data
+        });
+        if (this.reducedMotion && this.animation) {
+          this.animation.goToAndStop(90, true);
+        }
+      }
+
+      updateColors(colors = {}) {
+        this.accent = resolveColorString(colors.accent, this.accent);
+        this.accentSecondary = resolveColorString(colors.accentSecondary, this.accentSecondary);
+        this.loadAnimation();
+      }
+
+      setReducedMotion(flag) {
+        this.reducedMotion = !!flag;
+        if (!this.animation) return;
+        if (this.reducedMotion) {
+          this.animation.pause();
+          this.animation.goToAndStop(120, true);
+        } else {
+          this.animation.play();
+        }
+      }
+
+      resize() {
+        // SVG scales automatically within the container.
+      }
+
+      destroy() {
+        if (this.animation) {
+          this.animation.destroy();
+          this.animation = null;
+        }
+        if (this.node && this.node.parentNode) {
+          this.node.parentNode.removeChild(this.node);
+        }
+        this.node = null;
+      }
+    }
+
+    class DuotoneFusionEngine {
+      constructor(container, options = {}) {
+        this.name = 'duotone-fusion';
+        this.container = container;
+        this.reducedMotion = !!options.reducedMotion;
+        this.layer = null;
+        this.timeline = null;
+        this.accent = resolveColorString(options.accent, '#38bdf8');
+        this.accentSecondary = resolveColorString(options.accentSecondary, '#f472b6');
+        if (!container) return;
+        this.layer = document.createElement('div');
+        this.layer.style.position = 'absolute';
+        this.layer.style.inset = '-40%';
+        this.layer.style.pointerEvents = 'none';
+        this.layer.style.opacity = '0.55';
+        this.layer.style.filter = 'blur(140px)';
+        this.layer.style.mixBlendMode = 'screen';
+        container.appendChild(this.layer);
+        this.updateGradient();
+        if (!this.reducedMotion && typeof gsap !== 'undefined') {
+          this.timeline = gsap.to(this.layer, {
+            duration: 16,
+            backgroundPosition: '200% 50%',
+            ease: 'none',
+            repeat: -1,
+            yoyo: true
+          });
+        }
+      }
+
+      updateGradient() {
+        if (!this.layer) return;
+        const primary = resolveColorString(this.accent, '#38bdf8');
+        const secondary = resolveColorString(this.accentSecondary, primary);
+        this.layer.style.background = `linear-gradient(135deg, ${primary}, ${secondary})`;
+        this.layer.style.backgroundSize = '200% 200%';
+      }
+
+      updateColors(colors = {}) {
+        this.accent = resolveColorString(colors.accent, this.accent);
+        this.accentSecondary = resolveColorString(colors.accentSecondary, this.accentSecondary);
+        this.updateGradient();
+      }
+
+      setReducedMotion(flag) {
+        this.reducedMotion = !!flag;
+        if (this.timeline) {
+          if (this.reducedMotion) {
+            this.timeline.pause();
+          } else {
+            this.timeline.play();
+          }
+        }
+      }
+
+      resize() {
+        // Layer covers the container automatically via CSS.
+      }
+
+      destroy() {
+        if (this.timeline) {
+          this.timeline.kill();
+          this.timeline = null;
+        }
+        if (this.layer && this.layer.parentNode) {
+          this.layer.parentNode.removeChild(this.layer);
+        }
+        this.layer = null;
+      }
+    }
+
+    class ThemeVisualController {
+      constructor(container, options = {}) {
+        this.container = container;
+        this.reducedMotion = !!options.reducedMotion;
+        this.current = null;
+      }
+
+      static get factories() {
+        if (!this._factories) {
+          this._factories = {
+            'midnight-glass': (container, opts) => new MidnightGlassEngine(container, opts),
+            'aurora-night': (container, opts) => new AuroraNightEngine(container, opts),
+            'nexus-grid': (container, opts) => new NexusGridEngine(container, opts),
+            'zen-flow': (container, opts) => new ZenFlowEngine(container, opts),
+            'duotone-fusion': (container, opts) => new DuotoneFusionEngine(container, opts)
+          };
+        }
+        return this._factories;
+      }
+
+      setTheme(theme, colors = {}) {
+        if (!this.container) return;
+        const factories = ThemeVisualController.factories;
+        const resolvedTheme = (theme && factories[theme]) ? theme : 'midnight-glass';
+        if (this.current && this.current.name === resolvedTheme) {
+          if (typeof this.current.updateColors === 'function') {
+            this.current.updateColors(colors);
+          }
+          return;
+        }
+        if (this.current && typeof this.current.destroy === 'function') {
+          this.current.destroy();
+        }
+        if (this.container) {
+          this.container.innerHTML = '';
+        }
+        const factory = factories[resolvedTheme];
+        this.current = factory ? factory(this.container, { ...colors, reducedMotion: this.reducedMotion }) : null;
+      }
+
+      updateColors(colors = {}) {
+        if (this.current && typeof this.current.updateColors === 'function') {
+          this.current.updateColors(colors);
+        }
+      }
+
+      setReducedMotion(flag) {
+        this.reducedMotion = !!flag;
+        if (this.current && typeof this.current.setReducedMotion === 'function') {
+          this.current.setReducedMotion(this.reducedMotion);
+        }
+      }
+
+      resize() {
+        if (this.current && typeof this.current.resize === 'function') {
+          this.current.resize();
+        }
+      }
+
+      destroy() {
+        if (this.current && typeof this.current.destroy === 'function') {
+          this.current.destroy();
+        }
+        this.current = null;
+        if (this.container) {
+          this.container.innerHTML = '';
+        }
+      }
+    }
+
     class TickerOverlay {
       constructor() {
         const params = new URLSearchParams(location.search);
@@ -1474,6 +2326,7 @@
         this.overrides = {
           label: false,
           accent: false,
+          accentSecondary: false,
           highlight: false,
           scale: false,
           popupScale: false,
@@ -1501,6 +2354,20 @@
             this.overrides.accent = true;
           } else {
             console.warn('[ticker] ignoring unsafe accent override', trimmed);
+          }
+        }
+
+        const accentSecondaryParam = params.get('accentSecondary');
+        if (accentSecondaryParam !== null) {
+          const trimmedSecondary = accentSecondaryParam.trim();
+          if (!trimmedSecondary) {
+            this.overlay.accentSecondary = '';
+            this.overrides.accentSecondary = true;
+          } else if (isSafeCssColor(trimmedSecondary)) {
+            this.overlay.accentSecondary = trimmedSecondary;
+            this.overrides.accentSecondary = true;
+          } else {
+            console.warn('[ticker] ignoring unsafe secondary accent override', trimmedSecondary);
           }
         }
 
@@ -1567,6 +2434,27 @@
         this.labelNode = document.getElementById('tickerLabel');
         this.contentNode = document.getElementById('tickerContent');
         this.trackNode = document.getElementById('tickerTrack');
+        this.visualContainer = document.getElementById('tickerVisuals');
+        this.themeVisuals = this.visualContainer
+          ? new ThemeVisualController(this.visualContainer, {
+              reducedMotion: prefersReducedMotionQuery ? prefersReducedMotionQuery.matches : false
+            })
+          : null;
+        this.handleResize = () => {
+          if (this.themeVisuals) {
+            this.themeVisuals.resize();
+          }
+        };
+        window.addEventListener('resize', this.handleResize);
+        if (prefersReducedMotionQuery && this.themeVisuals) {
+          this.reducedMotionListener = event => {
+            const shouldReduce = event.matches || this.overlay.accentAnim === false;
+            this.themeVisuals.setReducedMotion(shouldReduce);
+          };
+          prefersReducedMotionQuery.addEventListener('change', this.reducedMotionListener);
+        } else {
+          this.reducedMotionListener = null;
+        }
         this.popupNode = document.getElementById('popup');
         this.popupInner = document.getElementById('popupContent');
         this.slateNode = document.getElementById('slate');
@@ -1665,11 +2553,24 @@
           this.measureNode.parentNode.removeChild(this.measureNode);
           this.measureNode = null;
         }
+        if (this.handleResize) {
+          window.removeEventListener('resize', this.handleResize);
+          this.handleResize = null;
+        }
+        if (prefersReducedMotionQuery && this.reducedMotionListener) {
+          prefersReducedMotionQuery.removeEventListener('change', this.reducedMotionListener);
+          this.reducedMotionListener = null;
+        }
+        if (this.themeVisuals) {
+          this.themeVisuals.destroy();
+          this.themeVisuals = null;
+        }
         if (document.body) {
           document.body.classList.remove(...THEME_CLASSNAMES);
           document.body.classList.remove('no-sparkle');
         }
         document.documentElement.style.removeProperty('--accent');
+        document.documentElement.style.removeProperty('--accent-secondary');
       }
 
       clearTimers() {
@@ -2197,11 +3098,31 @@
         } else {
           document.documentElement.style.removeProperty('--accent');
         }
+        if (this.overlay.accentSecondary && isSafeCssColor(this.overlay.accentSecondary)) {
+          document.documentElement.style.setProperty('--accent-secondary', this.overlay.accentSecondary);
+        } else {
+          document.documentElement.style.removeProperty('--accent-secondary');
+        }
         document.documentElement.style.setProperty('--ui-scale', String(this.overlay.scale));
         document.documentElement.style.setProperty('--popup-scale', String(this.overlay.popupScale));
         this.cachedLongestMessageWidth = null;
         if (this.popupNode) {
           this.popupNode.classList.toggle('push-down', this.overlay.position === 'top');
+        }
+        if (this.themeVisuals) {
+          const computed = getComputedStyle(document.documentElement);
+          const accentValue = resolveColorString(
+            computed.getPropertyValue('--accent'),
+            this.overlay.accent || DEFAULT_OVERLAY.accent || '#38bdf8'
+          );
+          const secondaryValue = resolveColorString(
+            computed.getPropertyValue('--accent-secondary'),
+            this.overlay.accentSecondary || this.overlay.accent || DEFAULT_OVERLAY.accentSecondary || accentValue
+          );
+          this.themeVisuals.setTheme(theme, { accent: accentValue, accentSecondary: secondaryValue });
+          const shouldReduce = (prefersReducedMotionQuery ? prefersReducedMotionQuery.matches : false) || this.overlay.accentAnim === false;
+          this.themeVisuals.setReducedMotion(shouldReduce);
+          this.themeVisuals.resize();
         }
         if (refreshContent && this.phase === 'visible') {
           this.refreshVisible(true);
@@ -2233,6 +3154,21 @@
             }
           } else {
             console.warn('[ticker] ignoring unsafe accent update', accent);
+          }
+        }
+
+        if (!this.overrides.accentSecondary && typeof data.accentSecondary === 'string') {
+          const accentSecondary = data.accentSecondary.trim();
+          if (!accentSecondary) {
+            if (this.overlay.accentSecondary) {
+              this.overlay.accentSecondary = '';
+            }
+          } else if (isSafeCssColor(accentSecondary)) {
+            if (accentSecondary !== this.overlay.accentSecondary) {
+              this.overlay.accentSecondary = accentSecondary;
+            }
+          } else {
+            console.warn('[ticker] ignoring unsafe secondary accent update', accentSecondary);
           }
         }
 

--- a/server.js
+++ b/server.js
@@ -37,8 +37,11 @@ const {
 } = sharedConfig || {};
 const OVERLAY_THEME_SET = new Set(OVERLAY_THEMES);
 
-const HTTP_HOST = '127.0.0.1';
-const HTTP_PORT = 3000;
+const HTTP_HOST = process.env.HTTP_HOST || '127.0.0.1';
+const HTTP_PORT = (() => {
+  const raw = Number(process.env.HTTP_PORT);
+  return Number.isFinite(raw) && raw > 0 ? raw : 3000;
+})();
 
 // Serve only the public UI assets by default. Override via TICKER_DIR when needed.
 const DEFAULT_TICKER_DIR = path.join(__dirname, 'public');
@@ -70,7 +73,8 @@ const BASE_DEFAULT_OVERLAY = CONFIG_DEFAULT_OVERLAY
   ? { ...CONFIG_DEFAULT_OVERLAY }
   : {
       label: 'LIVE',
-      accent: '#ef4444',
+      accent: '#38bdf8',
+      accentSecondary: '#f472b6',
       highlight: DEFAULT_HIGHLIGHT_STRING,
       scale: 1.75,
       popupScale: 1,
@@ -78,7 +82,7 @@ const BASE_DEFAULT_OVERLAY = CONFIG_DEFAULT_OVERLAY
       mode: 'auto',
       accentAnim: true,
       sparkle: true,
-      theme: 'monotone'
+      theme: 'midnight-glass'
     };
 
 const BASE_DEFAULT_POPUP = CONFIG_DEFAULT_POPUP
@@ -749,6 +753,18 @@ function sanitiseOverlayInput(input, options = {}) {
       result.accent = trimmed;
     } else if (strict) {
       throw new Error('Accent must be a valid CSS colour.');
+    }
+  }
+  if (typeof input.accentSecondary === 'string') {
+    const trimmedSecondary = input.accentSecondary.trim();
+    if (!trimmedSecondary) {
+      result.accentSecondary = '';
+    } else if (trimmedSecondary.length > 64) {
+      if (strict) throw new Error('Secondary accent must be 64 characters or fewer.');
+    } else if (isSafeCssColor(trimmedSecondary)) {
+      result.accentSecondary = trimmedSecondary;
+    } else if (strict) {
+      throw new Error('Secondary accent must be a valid CSS colour.');
     }
   }
   if (typeof input.highlight === 'string') {

--- a/tests/client-normalisers.test.js
+++ b/tests/client-normalisers.test.js
@@ -21,7 +21,7 @@ test('normaliseOverlayData clamps values and is idempotent', () => {
     mode: 'Chunk',
     accentAnim: false,
     sparkle: false,
-    theme: 'Neon-Noir'
+    theme: 'Aurora-Night'
   };
 
   const result = normaliseOverlayData(input);
@@ -34,7 +34,7 @@ test('normaliseOverlayData clamps values and is idempotent', () => {
   assert.equal(result.mode, 'chunk');
   assert.equal(result.accentAnim, false);
   assert.equal(result.sparkle, false);
-  assert.equal(result.theme, 'neon-noir');
+  assert.equal(result.theme, 'aurora-night');
 
   assert.deepStrictEqual(normaliseOverlayData(result), result);
 });
@@ -98,7 +98,7 @@ test('normaliseSceneEntry rejects empty payloads and preserves round-trip data',
     displayDuration: 1,
     intervalBetween: 7200,
     isActive: true,
-    overlay: { theme: 'Neon-Noir' },
+    overlay: { theme: 'Aurora-Night' },
     popup: { text: '   ' },
     slate: {
       rotationSeconds: 3,
@@ -117,7 +117,7 @@ test('normaliseSceneEntry rejects empty payloads and preserves round-trip data',
   assert.equal(result.popup.isActive, false);
   assert.equal(result.slate.rotationSeconds, 4);
   assert.deepStrictEqual(result.slate.notes, ['alpha', 'beta']);
-  assert.deepStrictEqual(result.overlay, { theme: 'neon-noir' });
+  assert.deepStrictEqual(result.overlay, { theme: 'aurora-night' });
   assert.ok(Number.isFinite(result.updatedAt));
 
   assert.deepStrictEqual(normaliseSceneEntry(result), result);

--- a/tests/server.integration.test.js
+++ b/tests/server.integration.test.js
@@ -6,7 +6,9 @@ const fs = require('node:fs/promises');
 const path = require('node:path');
 const os = require('node:os');
 
-const BASE_URL = 'http://127.0.0.1:3000';
+const HOST = '127.0.0.1';
+const TEST_PORT = 3201;
+const BASE_URL = `http://${HOST}:${TEST_PORT}`;
 const REPO_ROOT = path.join(__dirname, '..');
 
 let tmpDir;
@@ -32,7 +34,7 @@ async function waitForServerReady(proc) {
 
     function onStdout(chunk) {
       const text = chunk.toString();
-      if (text.includes('listening on http://127.0.0.1:3000')) {
+      if (text.includes(`listening on http://${HOST}:${TEST_PORT}`)) {
         if (settled) return;
         settled = true;
         cleanup();
@@ -79,7 +81,9 @@ test.before(async () => {
     env: {
       ...process.env,
       NODE_ENV: 'test',
-      TICKER_STATE_FILE: stateFile
+      TICKER_STATE_FILE: stateFile,
+      HTTP_PORT: String(TEST_PORT),
+      HTTP_HOST: HOST
     },
     stdio: ['ignore', 'pipe', 'pipe']
   });
@@ -135,6 +139,7 @@ test('POST /ticker/scenes sanitises and persists payloads', async () => {
         overlay: {
           label: '  Live Now  ',
           accent: 'javascript:alert(1)',
+          accentSecondary: '  rgba(255, 0, 255, 0.8)  ',
           highlight: 'Alpha,,Beta',
           scale: 9,
           popupScale: 0,
@@ -142,7 +147,7 @@ test('POST /ticker/scenes sanitises and persists payloads', async () => {
           mode: 'Chunk',
           accentAnim: false,
           sparkle: false,
-          theme: 'Neon-Noir'
+          theme: '  Aurora-Night  '
         },
         popup: {
           text: '   Popup message   ',
@@ -177,13 +182,14 @@ test('POST /ticker/scenes sanitises and persists payloads', async () => {
   assert.equal(scene.popup.countdownTarget, null);
   assert.equal(scene.overlay.label, 'Live Now');
   assert.equal(scene.overlay.highlight, 'Alpha, Beta');
+  assert.equal(scene.overlay.accentSecondary, 'rgba(255, 0, 255, 0.8)');
   assert.equal(scene.overlay.scale, 2.5);
   assert.equal(scene.overlay.popupScale, 0.6);
   assert.equal(scene.overlay.position, 'top');
   assert.equal(scene.overlay.mode, 'chunk');
   assert.equal(scene.overlay.accentAnim, false);
   assert.equal(scene.overlay.sparkle, false);
-  assert.equal(scene.overlay.theme, 'neon-noir');
+  assert.equal(scene.overlay.theme, 'aurora-night');
   assert.equal(scene.slate.rotationSeconds, 4);
   assert.deepStrictEqual(scene.slate.notes, ['first', 'second']);
   assert.equal(scene.slate.notesLabel, 'Label');
@@ -225,6 +231,7 @@ test('POST /ticker/overlay sanitises overlay payloads', async () => {
   const payload = {
     label: '  BREAKING  ',
     accent: '  rgb(255, 0, 0)  ',
+    accentSecondary: '  #ABCDEF  ',
     highlight: 'One,,Two',
     scale: 8,
     popupScale: 0.2,
@@ -232,7 +239,7 @@ test('POST /ticker/overlay sanitises overlay payloads', async () => {
     mode: 'Chunk',
     sparkle: false,
     accentAnim: false,
-    theme: 'Neon-Noir'
+    theme: 'Zen-Flow'
   };
 
   const { response, data } = await postJson('/ticker/overlay', payload);
@@ -241,6 +248,7 @@ test('POST /ticker/overlay sanitises overlay payloads', async () => {
   const overlay = data.overlay;
   assert.equal(overlay.label, 'BREAKING');
   assert.equal(overlay.accent, 'rgb(255, 0, 0)');
+  assert.equal(overlay.accentSecondary, '#ABCDEF');
   assert.equal(overlay.highlight, 'One, Two');
   assert.equal(overlay.scale, 2.5);
   assert.equal(overlay.popupScale, 0.6);
@@ -248,7 +256,7 @@ test('POST /ticker/overlay sanitises overlay payloads', async () => {
   assert.equal(overlay.mode, 'chunk');
   assert.equal(overlay.sparkle, false);
   assert.equal(overlay.accentAnim, false);
-  assert.equal(overlay.theme, 'neon-noir');
+  assert.equal(overlay.theme, 'zen-flow');
 
   const { response: getResponse, data: getData } = await getJson('/ticker/overlay');
   assert.equal(getResponse.status, 200);

--- a/tests/state-roundtrip.test.js
+++ b/tests/state-roundtrip.test.js
@@ -8,7 +8,9 @@ const os = require('node:os');
 const { setTimeout: delay } = require('node:timers/promises');
 
 const ROOT_DIR = path.join(__dirname, '..');
-const BASE_URL = 'http://127.0.0.1:3000';
+const HOST = '127.0.0.1';
+const TEST_PORT = 3202;
+const BASE_URL = `http://${HOST}:${TEST_PORT}`;
 
 async function waitForServer() {
   for (let attempt = 0; attempt < 50; attempt += 1) {
@@ -58,7 +60,9 @@ test('ticker state export/import round-trips through the API', async t => {
     cwd: ROOT_DIR,
     env: {
       ...process.env,
-      TICKER_STATE_FILE: stateFile
+      TICKER_STATE_FILE: stateFile,
+      HTTP_PORT: String(TEST_PORT),
+      HTTP_HOST: HOST
     },
     stdio: ['ignore', 'pipe', 'pipe']
   });
@@ -104,6 +108,7 @@ test('ticker state export/import round-trips through the API', async t => {
     body: JSON.stringify({
       label: 'LIVE',
       accent: '#ff00ff',
+      accentSecondary: 'rgba(0, 255, 255, 0.8)',
       highlight: 'alpha,beta',
       scale: 1.2,
       popupScale: 1.05,
@@ -111,7 +116,7 @@ test('ticker state export/import round-trips through the API', async t => {
       mode: 'chunk',
       accentAnim: false,
       sparkle: false,
-      theme: 'neural'
+      theme: 'nexus-grid'
     })
   });
 
@@ -173,7 +178,8 @@ test('ticker state export/import round-trips through the API', async t => {
             durationSeconds: 15
           },
           overlay: {
-            theme: 'monotone'
+            accentSecondary: '#ffe066',
+            theme: 'duotone-fusion'
           },
           slate: {
             notes: ['Scene note one']


### PR DESCRIPTION
## Summary
- replace the legacy overlay themes with the new dark-mode collection and associated animations
- introduce secondary accent configuration through the dashboard, server, and overlay runtime
- update integration tests and server configuration to exercise the new theme list and colour handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5f44a64a88321a656fc3520e06a72