### PR TITLE
Allow full-length slate notes in dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1412,8 +1412,8 @@
               </div>
               <div class="control-group">
                 <label for="slateNotes">Spotlight notes (one per line)</label>
-                <textarea id="slateNotes" maxlength="600" placeholder="Follow @channelhandle&#10;Share your questions with #AskLive"></textarea>
-                <p class="control-hint">Up to six short lines rotate alongside the clock card.</p>
+                <textarea id="slateNotes" maxlength="1200" placeholder="Follow @channelhandle&#10;Share your questions with #AskLive"></textarea>
+                <p class="control-hint">Up to six lines (200 characters each) rotate alongside the clock card.</p>
               </div>
             </div>
             <div class="slate-preview is-empty is-visible" id="slatePreview">

--- a/tests/client-normalisers.test.js
+++ b/tests/client-normalisers.test.js
@@ -7,6 +7,7 @@ const {
   normaliseOverlayData,
   normalisePopupData,
   normaliseSlateData,
+  normaliseSlateNotesList,
   normaliseSceneEntry
 } = normalisers;
 
@@ -86,6 +87,19 @@ test('normaliseSlateData trims fields, limits notes, and is idempotent', () => {
   assert.deepStrictEqual(result.notes, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
 
   assert.deepStrictEqual(normaliseSlateData(result), result);
+});
+
+test('normaliseSlateNotesList allows six full-length lines', () => {
+  const lines = Array.from({ length: 6 }, (_, index) => `Line ${index + 1} `.padEnd(200, '#'));
+  const textBlock = lines.join('\n');
+
+  const result = normaliseSlateNotesList(textBlock);
+
+  assert.equal(result.length, 6);
+  result.forEach((line, index) => {
+    assert.equal(line.length, 200);
+    assert.equal(line, lines[index]);
+  });
 });
 
 test('normaliseSceneEntry rejects empty payloads and preserves round-trip data', () => {


### PR DESCRIPTION
## Summary
- raise the dashboard textarea limit so slate notes can enter the full server allowance and clarify the hint copy
- add a client-normaliser test that covers six 200-character notes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6006232b083219cdcc8926bd02745