### PR TITLE
Expand overlay label length allowance to 48 characters

### DIFF
--- a/backup/index.html
+++ b/backup/index.html
@@ -489,7 +489,8 @@
         <div class="control-grid">
           <div class="control-group">
             <label for="overlayLabel">Overlay Label</label>
-            <input type="text" id="overlayLabel" maxlength="32" />
+            <input type="text" id="overlayLabel" maxlength="48" />
+            <p class="control-hint">Overlay label can be up to 48 characters.</p>
           </div>
           <div class="control-group">
             <label for="overlayAccent">Accent Colour</label>

--- a/public/index.html
+++ b/public/index.html
@@ -1261,7 +1261,8 @@
           <div class="control-grid">
             <div class="control-group">
               <label for="overlayLabel">Overlay Label</label>
-              <input type="text" id="overlayLabel" maxlength="32" />
+              <input type="text" id="overlayLabel" maxlength="48" />
+              <p class="control-hint">Overlay label can be up to 48 characters.</p>
             </div>
             <div class="control-group">
               <label for="overlayAccent">Accent Colour</label>

--- a/tests/client-normalisers.test.js
+++ b/tests/client-normalisers.test.js
@@ -39,6 +39,17 @@ test('normaliseOverlayData clamps values and is idempotent', () => {
   assert.deepStrictEqual(normaliseOverlayData(result), result);
 });
 
+test('normaliseOverlayData preserves 48 character labels and trims overflow', () => {
+  const label48 = 'Overlay label length check '.padEnd(48, 'x');
+
+  const result = normaliseOverlayData({ label: label48 });
+  assert.equal(result.label, label48);
+
+  const overflow = normaliseOverlayData({ label: `${label48}overflow` });
+  assert.equal(overflow.label.length, 48);
+  assert.equal(overflow.label, label48);
+});
+
 test('normalisePopupData enforces countdown invariants and is idempotent', () => {
   const input = {
     text: '   Hello there   ',

--- a/tests/state-roundtrip.test.js
+++ b/tests/state-roundtrip.test.js
@@ -79,6 +79,8 @@ test('ticker state export/import round-trips through the API', async t => {
 
   await waitForServer();
 
+  const overlayLabel = 'Overlay label length check '.padEnd(48, 'x');
+
   const tickerPayload = {
     isActive: true,
     messages: ['Alpha', 'Beta', 'Gamma'],
@@ -106,7 +108,7 @@ test('ticker state export/import round-trips through the API', async t => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      label: 'LIVE',
+      label: overlayLabel,
       accent: '#ff00ff',
       accentSecondary: 'rgba(0, 255, 255, 0.8)',
       highlight: 'alpha,beta',
@@ -194,6 +196,7 @@ test('ticker state export/import round-trips through the API', async t => {
   assert.ok(exportResponse.ok, 'export endpoint should respond with 200');
   const exportedState = await exportResponse.json();
   assert.ok(exportedState && typeof exportedState === 'object', 'export should return JSON');
+  assert.equal(exportedState.overlay.label, overlayLabel, 'overlay label should retain 48 characters');
 
   // Mutate the state so the import has to overwrite everything
   await fetchJson(`${BASE_URL}/ticker/state`, {


### PR DESCRIPTION
## Summary
- raise the overlay label input limit to 48 characters and document the allowance in the UI
- cover 48-character overlay labels in the client normaliser and state round-trip tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6005f1ebc8321bdf882ebc77babfb