### PR TITLE
Limit highlight keywords input length

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -230,6 +230,7 @@
     .control-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 16px; }
     .control-group { display: flex; flex-direction: column; gap: 10px; }
     .control-hint { margin: 2px 0 0; font-size: 12px; color: rgba(201, 208, 230, 0.7); }
+    .control-hint.is-warning { color: rgba(255, 205, 130, 0.9); }
     .control-hint.is-error { color: rgba(255, 152, 152, 0.85); }
     .accent-inputs { display: flex; align-items: center; gap: 10px; }
     .accent-inputs input[type="color"] {
@@ -1281,7 +1282,8 @@
             </div>
             <div class="control-group">
               <label for="highlightWords">Highlight Words (comma separated)</label>
-              <input type="text" id="highlightWords" placeholder="YouTube,Twitch,breaking" />
+              <input type="text" id="highlightWords" placeholder="YouTube,Twitch,breaking" maxlength="512" />
+              <p class="control-hint" id="highlightWordsHint" aria-live="polite">Highlight words can be up to 512 characters. 512 characters remaining.</p>
             </div>
           </div>
           <div class="control-group">
@@ -1541,6 +1543,8 @@
     const MAX_SLATE_TITLE_LENGTH = EXPORTED_MAX_SLATE_TITLE_LENGTH || 64;
     const MAX_SLATE_TEXT_LENGTH = EXPORTED_MAX_SLATE_TEXT_LENGTH || 200;
     const MAX_SLATE_NOTES = EXPORTED_MAX_SLATE_NOTES || 6;
+    const MAX_HIGHLIGHT_LENGTH = 512;
+    const HIGHLIGHT_WARNING_THRESHOLD = 32;
     const MAX_BRB_LENGTH = 280;
     const MESSAGE_PLACEHOLDER = 'Add a ticker message…';
     const THEME_OPTIONS = Array.isArray(BASE_THEME_OPTIONS) && BASE_THEME_OPTIONS.length
@@ -1727,6 +1731,7 @@
       overlayAccentSecondaryGroup: document.getElementById('overlayAccentSecondaryGroup'),
       overlayAccentSecondaryHint: document.getElementById('overlayAccentSecondaryHint'),
       highlightWords: document.getElementById('highlightWords'),
+      highlightWordsHint: document.getElementById('highlightWordsHint'),
       scaleRange: document.getElementById('scaleRange'),
       scaleNumber: document.getElementById('scaleNumber'),
       popupScaleRange: document.getElementById('popupScaleRange'),
@@ -2728,6 +2733,19 @@
       }
     }
 
+    function updateHighlightHint(value) {
+      if (!el.highlightWordsHint) return;
+      const raw = typeof value === 'string'
+        ? value
+        : (el.highlightWords ? el.highlightWords.value : '');
+      const remaining = Math.max(0, MAX_HIGHLIGHT_LENGTH - raw.length);
+      const message = remaining === 0
+        ? `Highlight words can be up to ${MAX_HIGHLIGHT_LENGTH} characters. Limit reached.`
+        : `Highlight words can be up to ${MAX_HIGHLIGHT_LENGTH} characters. ${remaining} characters remaining.`;
+      el.highlightWordsHint.textContent = message;
+      el.highlightWordsHint.classList.toggle('is-warning', remaining <= HIGHLIGHT_WARNING_THRESHOLD);
+    }
+
     function applyPreviewTheme() {
       if (!el.popupPreview) return;
       const theme = overlayPrefs.theme && THEME_OPTIONS.includes(overlayPrefs.theme)
@@ -2755,6 +2773,7 @@
       setAccentError('');
       setAccentSecondaryError('');
       el.highlightWords.value = overlayPrefs.highlight;
+      updateHighlightHint(overlayPrefs.highlight);
       el.scaleRange.value = overlayPrefs.scale;
       el.scaleNumber.value = overlayPrefs.scale;
       if (el.popupScaleRange) el.popupScaleRange.value = overlayPrefs.popupScale;
@@ -4607,6 +4626,7 @@
 
     el.highlightWords.addEventListener('input', () => {
       const raw = el.highlightWords.value;
+      updateHighlightHint(raw);
       const normalised = normaliseHighlightInput(raw);
       const changed = overlayPrefs.highlight !== normalised;
       overlayPrefs.highlight = normalised;
@@ -4621,6 +4641,7 @@
     });
     el.highlightWords.addEventListener('blur', () => {
       el.highlightWords.value = overlayPrefs.highlight;
+      updateHighlightHint(overlayPrefs.highlight);
     });
 
     if (el.slateEnabled) {


### PR DESCRIPTION
## Summary
- add a 512 character limit to the highlight keywords input and surface the constraint in the form
- update the dashboard script to show a live remaining-character hint and warn when the limit is reached

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6006030f083219efe37b69ab45c17