### PR TITLE
Add overlay payload helper for scene saving

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1578,6 +1578,24 @@
       'theme'
     ];
 
+    const buildSceneOverlayPayload = serialiseOverlayForSceneImpl
+      ? (overlayPrefs = {}) => serialiseOverlayForSceneImpl(
+          overlayPrefs && typeof overlayPrefs === 'object' ? overlayPrefs : {},
+          normaliseOverlayData,
+          SCENE_OVERLAY_KEYS,
+          { includeEmptyStrings: false }
+        )
+      : (overlayPrefs = {}) => {
+          const source = overlayPrefs && typeof overlayPrefs === 'object' ? overlayPrefs : {};
+          const payload = {};
+          SCENE_OVERLAY_KEYS.forEach(key => {
+            if (Object.prototype.hasOwnProperty.call(source, key)) {
+              payload[key] = source[key];
+            }
+          });
+          return payload;
+        };
+
     const sharedConfig = window.SharedConfig || {};
     const DEFAULT_HIGHLIGHTS = Array.isArray(BASE_DEFAULT_HIGHLIGHTS) && BASE_DEFAULT_HIGHLIGHTS.length
       ? BASE_DEFAULT_HIGHLIGHTS.slice()


### PR DESCRIPTION
## Summary
- add a buildSceneOverlayPayload helper that wraps the existing scene serialiser when available
- provide a safe fallback that clones the allowed overlay keys so scene saves retain overlay data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d603e626588321981d0ca5408b6795