### PR TITLE
Preserve full overlay styling when saving scenes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1928,6 +1928,41 @@
       };
     }
 
+    function buildSceneOverlayPayload(source) {
+      if (!source || typeof source !== 'object') return null;
+
+      if (serialiseOverlayForSceneImpl) {
+        return serialiseOverlayForSceneImpl(source, {
+          normaliseOverlayData,
+          overlayKeys: SCENE_OVERLAY_KEYS,
+          includeEmptyStrings: true
+        });
+      }
+
+      const normalised = normaliseOverlayData(source);
+      const result = {};
+      let hasValue = false;
+
+      for (const key of SCENE_OVERLAY_KEYS) {
+        if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+        if (!(key in normalised)) continue;
+        const value = normalised[key];
+        if (value === undefined) continue;
+        result[key] = value;
+        hasValue = true;
+      }
+
+      if (!hasValue && Object.prototype.hasOwnProperty.call(source, 'theme')) {
+        const themeOnly = normaliseOverlayData({ theme: source.theme });
+        if (themeOnly && typeof themeOnly.theme === 'string' && themeOnly.theme) {
+          result.theme = themeOnly.theme;
+          hasValue = true;
+        }
+      }
+
+      return hasValue ? result : null;
+    }
+
     function deriveSlateCardsForPreview(slate, _overlay = overlayPrefs) {
       const cards = [];
       const activeSlate = normaliseSlateData(slate);
@@ -2862,8 +2897,30 @@
       if (popupText) {
         parts.push(scene.popup.isActive ? 'popup active' : 'popup ready');
       }
-      if (scene?.overlay?.theme) {
-        parts.push(`theme: ${scene.overlay.theme}`);
+      if (scene?.overlay) {
+        const overlayLabel = typeof scene.overlay.label === 'string'
+          ? scene.overlay.label.trim()
+          : '';
+        if (overlayLabel) {
+          parts.push(`label: ${overlayLabel}`);
+        }
+        if (scene.overlay.theme) {
+          parts.push(`theme: ${scene.overlay.theme}`);
+        }
+        if (typeof scene.overlay.scale === 'number' && Number.isFinite(scene.overlay.scale)
+          && scene.overlay.scale !== DEFAULT_OVERLAY.scale) {
+          parts.push(`scale ${scene.overlay.scale}×`);
+        }
+        if (typeof scene.overlay.popupScale === 'number' && Number.isFinite(scene.overlay.popupScale)
+          && scene.overlay.popupScale !== DEFAULT_OVERLAY.popupScale) {
+          parts.push(`popup ${scene.overlay.popupScale}×`);
+        }
+        if (scene.overlay.mode && scene.overlay.mode !== DEFAULT_OVERLAY.mode) {
+          parts.push(`mode: ${scene.overlay.mode}`);
+        }
+        if (scene.overlay.position && scene.overlay.position !== DEFAULT_OVERLAY.position) {
+          parts.push(`${scene.overlay.position} overlay`);
+        }
       }
       if (scene?.slate) {
         if (scene.slate.isEnabled) {
@@ -4219,13 +4276,8 @@
         slate: serialiseSlateState(),
         updatedAt: Date.now()
       };
-      if (overlay && Object.keys(overlay).length) {
-        if (!overlay.theme) delete overlay.theme;
-        if (!overlay.position) delete overlay.position;
-        if (!overlay.mode) delete overlay.mode;
-        if (Object.keys(overlay).length) {
-          payload.overlay = overlay;
-        }
+      if (overlay) {
+        payload.overlay = overlay;
       }
       return payload;
     }

--- a/public/js/client-normalisers.js
+++ b/public/js/client-normalisers.js
@@ -513,13 +513,39 @@
 
     let overlay = null;
     if (entry.overlay && typeof entry.overlay === 'object') {
-      const rawTheme = entry.overlay.theme;
-      if (typeof rawTheme === 'string') {
-        const normalisedTheme = typeof sharedUtils.normaliseTheme === 'function'
-          ? sharedUtils.normaliseTheme(rawTheme)
-          : rawTheme.trim().toLowerCase();
-        if (normalisedTheme && themeSet.has(normalisedTheme)) {
-          overlay = { theme: normalisedTheme };
+      const overlayKeys = [
+        'label',
+        'accent',
+        'accentSecondary',
+        'highlight',
+        'scale',
+        'popupScale',
+        'position',
+        'mode',
+        'accentAnim',
+        'sparkle',
+        'theme'
+      ];
+
+      const normalisedOverlay = normaliseOverlayData(entry.overlay, defaultOverlay);
+      for (const key of overlayKeys) {
+        if (!Object.prototype.hasOwnProperty.call(entry.overlay, key)) continue;
+        if (!(key in normalisedOverlay)) continue;
+        const value = normalisedOverlay[key];
+        if (value === undefined) continue;
+        if (!overlay) overlay = {};
+        overlay[key] = value;
+      }
+
+      if (!overlay && Object.prototype.hasOwnProperty.call(entry.overlay, 'theme')) {
+        const rawTheme = entry.overlay.theme;
+        if (typeof rawTheme === 'string') {
+          const normalisedTheme = typeof sharedUtils.normaliseTheme === 'function'
+            ? sharedUtils.normaliseTheme(rawTheme)
+            : rawTheme.trim().toLowerCase();
+          if (normalisedTheme && themeSet.has(normalisedTheme)) {
+            overlay = { theme: normalisedTheme };
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- ensure the client normaliser keeps all overlay styling fields when loading scenes
- serialise the complete overlay configuration when building scene payloads in the dashboard, reusing shared helpers when available
- surface additional overlay metadata in the scene summary chips

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d603390fa083219735e7c25a8866cb