### PR TITLE
Refactor message sanitiser into shared utils

### DIFF
--- a/public/js/client-normalisers.js
+++ b/public/js/client-normalisers.js
@@ -20,13 +20,38 @@
     'duotone-fusion'
   ];
 
-  const MAX_MESSAGES = 50;
-  const MAX_MESSAGE_LENGTH = 280;
-  const MAX_POPUP_SECONDS = 600;
-  const MAX_SCENE_NAME_LENGTH = 80;
-  const MAX_SLATE_TITLE_LENGTH = 64;
-  const MAX_SLATE_TEXT_LENGTH = 200;
-  const MAX_SLATE_NOTES = 6;
+  const {
+    MAX_TICKER_MESSAGES: SHARED_MAX_TICKER_MESSAGES,
+    MAX_TICKER_MESSAGE_LENGTH: SHARED_MAX_MESSAGE_LENGTH,
+    MAX_POPUP_DURATION_SECONDS: SHARED_MAX_POPUP_SECONDS,
+    MAX_SCENE_NAME_LENGTH: SHARED_MAX_SCENE_NAME_LENGTH,
+    MAX_SLATE_TITLE_LENGTH: SHARED_MAX_SLATE_TITLE_LENGTH,
+    MAX_SLATE_TEXT_LENGTH: SHARED_MAX_SLATE_TEXT_LENGTH,
+    MAX_SLATE_NOTES: SHARED_MAX_SLATE_NOTES,
+    sanitiseMessages: sharedSanitiseMessages
+  } = sharedUtils || {};
+
+  const MAX_MESSAGES = Number.isFinite(SHARED_MAX_TICKER_MESSAGES)
+    ? SHARED_MAX_TICKER_MESSAGES
+    : 50;
+  const MAX_MESSAGE_LENGTH = Number.isFinite(SHARED_MAX_MESSAGE_LENGTH)
+    ? SHARED_MAX_MESSAGE_LENGTH
+    : 280;
+  const MAX_POPUP_SECONDS = Number.isFinite(SHARED_MAX_POPUP_SECONDS)
+    ? SHARED_MAX_POPUP_SECONDS
+    : 600;
+  const MAX_SCENE_NAME_LENGTH = Number.isFinite(SHARED_MAX_SCENE_NAME_LENGTH)
+    ? SHARED_MAX_SCENE_NAME_LENGTH
+    : 80;
+  const MAX_SLATE_TITLE_LENGTH = Number.isFinite(SHARED_MAX_SLATE_TITLE_LENGTH)
+    ? SHARED_MAX_SLATE_TITLE_LENGTH
+    : 64;
+  const MAX_SLATE_TEXT_LENGTH = Number.isFinite(SHARED_MAX_SLATE_TEXT_LENGTH)
+    ? SHARED_MAX_SLATE_TEXT_LENGTH
+    : 200;
+  const MAX_SLATE_NOTES = Number.isFinite(SHARED_MAX_SLATE_NOTES)
+    ? SHARED_MAX_SLATE_NOTES
+    : 6;
 
   const themeOptions = Array.isArray(sharedUtils.OVERLAY_THEMES) && sharedUtils.OVERLAY_THEMES.length
     ? sharedUtils.OVERLAY_THEMES.slice()
@@ -176,39 +201,51 @@
       .join(', ');
   }
 
-  function sanitiseMessages(list, options = {}) {
-    if (!Array.isArray(list)) {
-      return options.includeMeta ? { messages: [], trimmed: 0, truncated: 0 } : [];
-    }
-    const {
-      maxMessages = MAX_MESSAGES,
-      maxLength = MAX_MESSAGE_LENGTH,
-      includeMeta = false
-    } = options;
-
-    const cleaned = [];
-    let trimmedCount = 0;
-    let truncatedCount = 0;
-
-    for (const entry of list) {
-      let text = String(entry ?? '').trim();
-      if (!text) continue;
-      if (cleaned.length >= maxMessages) {
-        truncatedCount += 1;
-        continue;
+  const sanitiseMessages = typeof sharedSanitiseMessages === 'function'
+    ? function sanitiseMessages(list, options = {}) {
+        return sharedSanitiseMessages(list, {
+          maxMessages: MAX_MESSAGES,
+          maxLength: MAX_MESSAGE_LENGTH,
+          ...options
+        });
       }
-      if (text.length > maxLength) {
-        text = text.slice(0, maxLength);
-        trimmedCount += 1;
-      }
-      cleaned.push(text);
-    }
+    : function sanitiseMessages(list, options = {}) {
+        if (!Array.isArray(list)) {
+          return options.includeMeta ? { messages: [], trimmed: 0, truncated: 0 } : [];
+        }
 
-    if (includeMeta) {
-      return { messages: cleaned, trimmed: trimmedCount, truncated: truncatedCount };
-    }
-    return cleaned;
-  }
+        const {
+          maxMessages = MAX_MESSAGES,
+          maxLength = MAX_MESSAGE_LENGTH,
+          includeMeta = false
+        } = options;
+
+        const cleaned = [];
+        let trimmedCount = 0;
+        let truncatedCount = 0;
+
+        for (const entry of list) {
+          let text = String(entry ?? '').trim();
+          if (!text) continue;
+
+          if (cleaned.length >= maxMessages) {
+            truncatedCount += 1;
+            continue;
+          }
+
+          if (text.length > maxLength) {
+            text = text.slice(0, maxLength);
+            trimmedCount += 1;
+          }
+
+          cleaned.push(text);
+        }
+
+        if (includeMeta) {
+          return { messages: cleaned, trimmed: trimmedCount, truncated: truncatedCount };
+        }
+        return cleaned;
+      };
 
   function normaliseOverlayData(data, defaults = defaultOverlay) {
     const base = {

--- a/server.js
+++ b/server.js
@@ -16,6 +16,14 @@ const sharedUtils = require('./public/js/shared-utils.js');
 const sharedConfig = require('./public/js/shared-config.js');
 const {
   OVERLAY_THEMES,
+  MAX_TICKER_MESSAGES,
+  MAX_TICKER_MESSAGE_LENGTH,
+  MAX_POPUP_DURATION_SECONDS,
+  MAX_SCENE_NAME_LENGTH,
+  MAX_SLATE_TITLE_LENGTH,
+  MAX_SLATE_TEXT_LENGTH,
+  MAX_SLATE_NOTES,
+  sanitiseMessages,
   clampDurationSeconds,
   clampIntervalSeconds,
   clampScaleValue,
@@ -53,14 +61,6 @@ const STATE_FILE_INPUT = process.env.TICKER_STATE_FILE || DEFAULT_STATE_FILE;
 const STATE_FILE = path.resolve(STATE_FILE_INPUT);
 
 const PERSIST_DEBOUNCE_MS = 150;
-const MAX_TICKER_MESSAGES = 50;
-const MAX_TICKER_MESSAGE_LENGTH = 280;
-const MAX_POPUP_DURATION_SECONDS = 600;
-const MAX_SCENE_NAME_LENGTH = 80;
-const MAX_SLATE_TITLE_LENGTH = 64;
-const MAX_SLATE_TEXT_LENGTH = 200;
-const MAX_SLATE_NOTES = 6;
-
 const FALLBACK_HIGHLIGHTS = ['live', 'breaking', 'alert', 'update', 'tonight', 'today'];
 const DEFAULT_HIGHLIGHTS = Array.isArray(CONFIG_DEFAULT_HIGHLIGHTS) && CONFIG_DEFAULT_HIGHLIGHTS.length
   ? CONFIG_DEFAULT_HIGHLIGHTS.slice()
@@ -469,38 +469,6 @@ app.use('/ticker', express.static(PUBLIC_TICKER, {
 }));
 
 // ---- State persistence helpers
-function sanitiseMessages(list, options = {}) {
-  if (!Array.isArray(list)) return [];
-  const {
-    strict = false,
-    maxMessages = MAX_TICKER_MESSAGES,
-    maxLength = MAX_TICKER_MESSAGE_LENGTH
-  } = options;
-
-  const cleaned = [];
-  for (const entry of list) {
-    if (cleaned.length >= maxMessages) {
-      if (strict) {
-        throw new Error(`Too many ticker messages (maximum ${maxMessages}).`);
-      }
-      break;
-    }
-
-    const trimmed = String(entry ?? '').trim();
-    if (!trimmed) continue;
-
-    if (trimmed.length > maxLength) {
-      if (strict) {
-        throw new Error(`Ticker messages must be ${maxLength} characters or fewer.`);
-      }
-      cleaned.push(trimmed.slice(0, maxLength));
-    } else {
-      cleaned.push(trimmed);
-    }
-  }
-  return cleaned;
-}
-
 function sanitisePopupInput(input) {
   const result = {};
   if (input && typeof input === 'object') {


### PR DESCRIPTION
## Summary
- export shared ticker limits and sanitiseMessages helper from shared-utils
- update server and client normalisers to consume the shared sanitiser and constants
- extend shared utils tests to cover sanitiseMessages behaviour

## Testing
- node --test tests/server.integration.test.js
- node --test tests/client-normalisers.test.js
- node --test tests/scene-normaliser.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d603f15a9c8321ba10d31ad9fe8256