### PR TITLE
Add active/inactive status styling cues

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -222,6 +222,8 @@
     }
     .status-dot.active { background: var(--success); box-shadow: 0 0 0 4px rgba(61, 220, 151, 0.22); }
     .status-value { color: var(--text); font-weight: 600; }
+    .status-value.is-active { color: color-mix(in srgb, var(--success) 55%, var(--accent) 45%); }
+    .status-value.is-inactive { color: var(--subtle); }
     .status-value.is-full { color: var(--danger); }
 
     .section-title { font-size: 18px; font-weight: 600; letter-spacing: 0.2px; }
@@ -2676,6 +2678,8 @@
       el.interval.value = formatMinutesValue(state.intervalMinutes);
       el.statusActive.classList.toggle('active', state.isActive);
       el.statusActiveText.textContent = state.isActive ? 'Active' : 'Inactive';
+      el.statusActiveText.classList.toggle('is-active', state.isActive);
+      el.statusActiveText.classList.toggle('is-inactive', !state.isActive);
       const count = state.messages.length;
       const queueFull = count >= MAX_MESSAGES;
       el.statusCount.textContent = `${count}/${MAX_MESSAGES}`;


### PR DESCRIPTION
## Summary
- add new CSS helpers to style the active state indicator label
- toggle the status label classes in renderTicker so it reflects the ticker state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6038acb3c8321a82f367631b837b7