### PR TITLE
Add helper to normalise scene overlay payloads

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1578,6 +1578,38 @@
       'theme'
     ];
 
+    function buildSceneOverlayPayload(rawOverlay) {
+      if (!rawOverlay || typeof rawOverlay !== 'object') return null;
+
+      if (serialiseOverlayForSceneImpl) {
+        const overlay = serialiseOverlayForSceneImpl(rawOverlay, {
+          normaliseOverlayData: typeof normaliseOverlayData === 'function'
+            ? normaliseOverlayData
+            : null,
+          overlayKeys: SCENE_OVERLAY_KEYS,
+          includeEmptyStrings: false
+        });
+        return overlay && typeof overlay === 'object' && Object.keys(overlay).length
+          ? overlay
+          : null;
+      }
+
+      const result = {};
+      for (const key of SCENE_OVERLAY_KEYS) {
+        if (!Object.prototype.hasOwnProperty.call(rawOverlay, key)) continue;
+        const value = rawOverlay[key];
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (!trimmed) continue;
+          result[key] = trimmed;
+        } else if (value !== undefined && value !== null) {
+          result[key] = value;
+        }
+      }
+
+      return Object.keys(result).length ? result : null;
+    }
+
     const sharedConfig = window.SharedConfig || {};
     const DEFAULT_HIGHLIGHTS = Array.isArray(BASE_DEFAULT_HIGHLIGHTS) && BASE_DEFAULT_HIGHLIGHTS.length
       ? BASE_DEFAULT_HIGHLIGHTS.slice()


### PR DESCRIPTION
## Summary
- add a buildSceneOverlayPayload helper that reuses the shared serialiser when available
- fall back to trimming overlay fields manually and integrate the helper into scene payload creation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d603aeab24832185e9ca70e5551b26