### PR TITLE
Add duration countdown mode to popup configuration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -464,6 +464,27 @@
       border-color: var(--accent);
       box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.25);
     }
+    .popup-countdown-mode {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 12px;
+      text-transform: none;
+      letter-spacing: normal;
+      color: var(--subtle);
+    }
+    .popup-countdown-mode label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-weight: 500;
+      color: var(--text);
+      cursor: pointer;
+    }
+    .popup-countdown-input[data-mode="target"] [data-countdown-field="seconds"],
+    .popup-countdown-input[data-mode="duration"] [data-countdown-field="target"] {
+      display: none;
+    }
     .popup-preview {
       position: relative;
       display: flex;
@@ -1448,9 +1469,14 @@
           </div>
           <div class="popup-countdown">
             <label class="popup-countdown-toggle"><input type="checkbox" id="popupCountdownEnabled" /> Append countdown timer</label>
-            <div class="popup-countdown-input">
+            <div class="popup-countdown-input" id="popupCountdownInput" data-mode="target">
               <label for="popupCountdownTarget">Countdown target</label>
-              <input type="datetime-local" id="popupCountdownTarget" />
+              <div class="popup-countdown-mode" role="radiogroup" aria-label="Countdown mode">
+                <label><input type="radio" name="popupCountdownMode" value="target" checked /> Target time</label>
+                <label><input type="radio" name="popupCountdownMode" value="duration" /> Duration</label>
+              </div>
+              <input type="datetime-local" id="popupCountdownTarget" data-countdown-field="target" />
+              <input type="number" id="popupCountdownSeconds" data-countdown-field="seconds" min="1" step="1" placeholder="Seconds" inputmode="numeric" />
             </div>
           </div>
           <div class="popup-preview is-empty" id="popupPreview">Popup preview</div>
@@ -1632,8 +1658,10 @@
       text: '',
       isActive: false,
       durationSeconds: null,
+      countdownMode: 'target',
       countdownEnabled: false,
       countdownTarget: null,
+      countdownSeconds: null,
       ...(BASE_DEFAULT_POPUP || {}),
       ...(sharedConfig.DEFAULT_POPUP || {}),
       updatedAt: null
@@ -1669,6 +1697,10 @@
       isActive: false,
       updatedAt: null
     };
+
+    const COUNTDOWN_MODE_TARGET = 'target';
+    const COUNTDOWN_MODE_DURATION = 'duration';
+    const COUNTDOWN_MODES = new Set([COUNTDOWN_MODE_TARGET, COUNTDOWN_MODE_DURATION]);
 
     const hasRandomUUID = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function';
 
@@ -1762,7 +1794,10 @@
       popupMeta: document.getElementById('popupMeta'),
       popupDuration: document.getElementById('popupDuration'),
       popupCountdownEnabled: document.getElementById('popupCountdownEnabled'),
+      popupCountdownInput: document.getElementById('popupCountdownInput'),
       popupCountdownTarget: document.getElementById('popupCountdownTarget'),
+      popupCountdownSeconds: document.getElementById('popupCountdownSeconds'),
+      popupCountdownModeInputs: Array.from(document.querySelectorAll('input[name="popupCountdownMode"]')),
       savePopup: document.getElementById('savePopup'),
       clearPopup: document.getElementById('clearPopup'),
       slateEnabled: document.getElementById('slateEnabled'),
@@ -2609,17 +2644,86 @@
       return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
     }
 
-    function parseCountdownTarget(value) {
-      if (value === null || value === undefined) return null;
+    function normaliseCountdownMode(value) {
+      const mode = String(value || '').toLowerCase();
+      return COUNTDOWN_MODES.has(mode) ? mode : COUNTDOWN_MODE_TARGET;
+    }
+
+    function normaliseCountdownSeconds(value) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric <= 0) return null;
+      return Math.max(1, Math.round(numeric));
+    }
+
+    function parseCountdownTarget(value, mode = COUNTDOWN_MODE_TARGET, options = {}) {
+      const resolvedMode = normaliseCountdownMode(mode);
+      if (resolvedMode === COUNTDOWN_MODE_DURATION) {
+        const seconds = normaliseCountdownSeconds(value);
+        if (seconds === null) {
+          return { target: null, seconds: null };
+        }
+        const now = Number.isFinite(options.now) ? options.now : Date.now();
+        return { target: now + seconds * 1000, seconds };
+      }
+      if (value === null || value === undefined) {
+        return { target: null, seconds: null };
+      }
       const raw = String(value).trim();
-      if (!raw) return null;
+      if (!raw) {
+        return { target: null, seconds: null };
+      }
       const numeric = Number(raw);
       if (Number.isFinite(numeric) && numeric > 0) {
-        return Math.round(numeric);
+        return { target: Math.round(numeric), seconds: null };
       }
       const parsed = new Date(raw);
       const ms = parsed.getTime();
-      return Number.isNaN(ms) ? null : ms;
+      return { target: Number.isNaN(ms) ? null : ms, seconds: null };
+    }
+
+    function getCountdownModeFromInputs(fallback = popupState.countdownMode) {
+      const fallbackMode = normaliseCountdownMode(fallback);
+      if (!Array.isArray(el.popupCountdownModeInputs) || !el.popupCountdownModeInputs.length) {
+        return fallbackMode;
+      }
+      const checked = el.popupCountdownModeInputs.find(input => input && input.checked);
+      return checked ? normaliseCountdownMode(checked.value) : fallbackMode;
+    }
+
+    function setCountdownModeInputs(mode) {
+      const resolved = normaliseCountdownMode(mode);
+      if (Array.isArray(el.popupCountdownModeInputs)) {
+        for (const input of el.popupCountdownModeInputs) {
+          if (!input) continue;
+          input.checked = input.value === resolved;
+        }
+      }
+      if (el.popupCountdownInput) {
+        el.popupCountdownInput.dataset.mode = resolved;
+      }
+      return resolved;
+    }
+
+    function updateCountdownInputsDisabled() {
+      const mode = getCountdownModeFromInputs();
+      const hasText = !!(el.popupText && el.popupText.value.trim());
+      const countdownEnabled = !!(el.popupCountdownEnabled && el.popupCountdownEnabled.checked && hasText);
+      if (el.popupCountdownInput) {
+        el.popupCountdownInput.dataset.mode = mode;
+      }
+      if (el.popupCountdownTarget) {
+        const shouldDisable = popupSaveInFlight || !countdownEnabled || mode !== COUNTDOWN_MODE_TARGET;
+        el.popupCountdownTarget.disabled = shouldDisable;
+        if (!shouldDisable && mode === COUNTDOWN_MODE_TARGET) {
+          el.popupCountdownTarget.step = '1';
+        } else {
+          el.popupCountdownTarget.removeAttribute('step');
+        }
+      }
+      if (el.popupCountdownSeconds) {
+        const shouldDisable = popupSaveInFlight || !countdownEnabled || mode !== COUNTDOWN_MODE_DURATION;
+        el.popupCountdownSeconds.disabled = shouldDisable;
+      }
     }
 
     function formatCountdownLabel(targetMs) {
@@ -2996,9 +3100,29 @@
         el.popupPreview.appendChild(messageNode);
         shouldAnimate = text !== previous;
         if (el.popupCountdownEnabled && el.popupCountdownEnabled.checked) {
-          const target = el.popupCountdownTarget ? parseCountdownTarget(el.popupCountdownTarget.value) : null;
-          if (Number.isFinite(target)) {
-            popupPreviewCountdownTarget = target;
+          const mode = getCountdownModeFromInputs();
+          let parsed = { target: null, seconds: null };
+          if (mode === COUNTDOWN_MODE_DURATION) {
+            const rawSeconds = el.popupCountdownSeconds ? el.popupCountdownSeconds.value : '';
+            parsed = parseCountdownTarget(rawSeconds, mode);
+            if (el.popupCountdownSeconds && parsed.seconds !== null) {
+              const displaySeconds = String(parsed.seconds);
+              if (el.popupCountdownSeconds.value !== displaySeconds) {
+                el.popupCountdownSeconds.value = displaySeconds;
+              }
+            }
+          } else {
+            const rawTarget = el.popupCountdownTarget ? el.popupCountdownTarget.value : '';
+            parsed = parseCountdownTarget(rawTarget, mode);
+            if (el.popupCountdownTarget && Number.isFinite(parsed.target)) {
+              const formatted = formatDatetimeLocal(parsed.target);
+              if (formatted && el.popupCountdownTarget.value !== formatted) {
+                el.popupCountdownTarget.value = formatted;
+              }
+            }
+          }
+          if (Number.isFinite(parsed.target)) {
+            popupPreviewCountdownTarget = parsed.target;
             const countdownChip = document.createElement('span');
             countdownChip.className = 'popup-countdown-chip';
             countdownChip.dataset.popupCountdown = 'true';
@@ -3014,14 +3138,8 @@
         if (el.popupCountdownEnabled) {
           el.popupCountdownEnabled.checked = false;
         }
-        if (el.popupCountdownTarget) {
-          el.popupCountdownTarget.disabled = true;
-        }
       }
-      if (el.popupCountdownTarget && el.popupCountdownEnabled) {
-        const countdownActive = el.popupCountdownEnabled.checked;
-        el.popupCountdownTarget.disabled = popupSaveInFlight || !countdownActive;
-      }
+      updateCountdownInputsDisabled();
       if (shouldAnimate && messageNode) {
         const animator = createTextAnimator(messageNode);
         if (animator) {
@@ -3039,8 +3157,20 @@
       if (durationLabel) {
         parts.push(`Auto-hide ${durationLabel}`);
       }
-      if (popupState.countdownEnabled && Number.isFinite(popupState.countdownTarget)) {
-        parts.push(`Countdown ${formatCountdownLabel(popupState.countdownTarget)}`);
+      if (popupState.countdownEnabled) {
+        const mode = normaliseCountdownMode(popupState.countdownMode);
+        if (mode === COUNTDOWN_MODE_DURATION) {
+          if (Number.isFinite(popupState.countdownTarget)) {
+            parts.push(`Countdown ${formatCountdownLabel(popupState.countdownTarget)}`);
+          } else if (Number.isFinite(popupState.countdownSeconds)) {
+            const label = formatDurationSeconds(popupState.countdownSeconds);
+            if (label) {
+              parts.push(`Countdown ${label}`);
+            }
+          }
+        } else if (Number.isFinite(popupState.countdownTarget)) {
+          parts.push(`Countdown ${formatCountdownLabel(popupState.countdownTarget)}`);
+        }
       }
       if (popupState.updatedAt) {
         parts.push(`Updated ${new Date(popupState.updatedAt).toLocaleTimeString()}`);
@@ -3061,14 +3191,27 @@
       if (el.popupDuration) {
         el.popupDuration.value = popupState.durationSeconds ? String(popupState.durationSeconds) : '';
       }
+      const countdownMode = setCountdownModeInputs(popupState.countdownMode);
+      const hasCountdownValue = countdownMode === COUNTDOWN_MODE_DURATION
+        ? Number.isFinite(popupState.countdownSeconds)
+        : Number.isFinite(popupState.countdownTarget);
       if (el.popupCountdownEnabled) {
-        const hasCountdown = popupState.countdownEnabled && Number.isFinite(popupState.countdownTarget);
+        const hasCountdown = popupState.countdownEnabled && hasCountdownValue;
         el.popupCountdownEnabled.checked = hasCountdown && !!popupState.text;
       }
       if (el.popupCountdownTarget) {
-        el.popupCountdownTarget.value = popupState.countdownEnabled && Number.isFinite(popupState.countdownTarget)
-          ? formatDatetimeLocal(popupState.countdownTarget)
-          : '';
+        if (countdownMode === COUNTDOWN_MODE_TARGET && Number.isFinite(popupState.countdownTarget)) {
+          el.popupCountdownTarget.value = formatDatetimeLocal(popupState.countdownTarget);
+        } else {
+          el.popupCountdownTarget.value = '';
+        }
+      }
+      if (el.popupCountdownSeconds) {
+        if (countdownMode === COUNTDOWN_MODE_DURATION && Number.isFinite(popupState.countdownSeconds)) {
+          el.popupCountdownSeconds.value = String(popupState.countdownSeconds);
+        } else {
+          el.popupCountdownSeconds.value = '';
+        }
       }
       updatePopupPreview();
       updatePopupMeta();
@@ -3078,10 +3221,7 @@
       el.popupActive.disabled = disabled;
       if (el.popupDuration) el.popupDuration.disabled = disabled;
       if (el.popupCountdownEnabled) el.popupCountdownEnabled.disabled = disabled;
-      if (el.popupCountdownTarget) {
-        const countdownEnabled = el.popupCountdownEnabled && el.popupCountdownEnabled.checked;
-        el.popupCountdownTarget.disabled = disabled || !countdownEnabled;
-      }
+      updateCountdownInputsDisabled();
       if (el.savePopup) el.savePopup.disabled = disabled;
       if (el.clearPopup) el.clearPopup.disabled = disabled;
     }
@@ -3424,35 +3564,49 @@
         }
       }
 
+      const countdownMode = getCountdownModeFromInputs(popupState.countdownMode);
       let countdownEnabled = el.popupCountdownEnabled ? el.popupCountdownEnabled.checked : false;
       if (!text) {
         countdownEnabled = false;
       }
       let countdownTarget = popupState.countdownTarget;
-      if (countdownEnabled) {
-        const rawCountdown = el.popupCountdownTarget ? el.popupCountdownTarget.value : '';
-        if (rawCountdown) {
-          const parsedCountdown = parseCountdownTarget(rawCountdown);
-          if (Number.isFinite(parsedCountdown)) {
-            countdownTarget = parsedCountdown;
-            if (el.popupCountdownTarget) {
-              const formatted = formatDatetimeLocal(parsedCountdown);
-              if (formatted) {
-                el.popupCountdownTarget.value = formatted;
-              }
-            }
+      let countdownSeconds = popupState.countdownSeconds;
+      if (countdownMode === COUNTDOWN_MODE_DURATION) {
+        const rawSeconds = el.popupCountdownSeconds ? el.popupCountdownSeconds.value.trim() : '';
+        const parsed = rawSeconds ? normaliseCountdownSeconds(rawSeconds) : null;
+        countdownSeconds = parsed;
+        if (el.popupCountdownSeconds) {
+          const display = parsed !== null ? String(parsed) : '';
+          if (el.popupCountdownSeconds.value !== display) {
+            el.popupCountdownSeconds.value = display;
+          }
+        }
+        if (countdownEnabled) {
+          if (Number.isFinite(countdownSeconds)) {
+            countdownTarget = Date.now() + countdownSeconds * 1000;
           } else {
             countdownEnabled = false;
             countdownTarget = null;
-            toast('Enter a valid countdown target');
+            toast('Enter a valid countdown duration in seconds');
           }
-        } else if (!Number.isFinite(countdownTarget)) {
-          countdownEnabled = false;
+        } else {
           countdownTarget = null;
-          toast('Select a countdown target time');
         }
       } else {
-        countdownTarget = null;
+        const rawCountdown = el.popupCountdownTarget ? el.popupCountdownTarget.value : '';
+        const parsedCountdown = rawCountdown ? parseCountdownTarget(rawCountdown, COUNTDOWN_MODE_TARGET) : { target: null };
+        countdownTarget = Number.isFinite(parsedCountdown.target) ? parsedCountdown.target : null;
+        if (el.popupCountdownTarget) {
+          const formatted = Number.isFinite(countdownTarget) ? formatDatetimeLocal(countdownTarget) : '';
+          if (el.popupCountdownTarget.value !== formatted) {
+            el.popupCountdownTarget.value = formatted;
+          }
+        }
+        if (countdownEnabled && !Number.isFinite(countdownTarget)) {
+          countdownEnabled = false;
+          toast('Select a countdown target time');
+        }
+        countdownSeconds = null;
       }
       if (el.popupCountdownEnabled && !countdownEnabled) {
         el.popupCountdownEnabled.checked = false;
@@ -3463,16 +3617,20 @@
         text,
         isActive,
         durationSeconds,
+        countdownMode,
         countdownEnabled,
-        countdownTarget
+        countdownTarget,
+        countdownSeconds
       };
 
       const changed =
         popupState.text !== nextState.text ||
         popupState.isActive !== nextState.isActive ||
         popupState.durationSeconds !== nextState.durationSeconds ||
+        popupState.countdownMode !== nextState.countdownMode ||
         popupState.countdownEnabled !== nextState.countdownEnabled ||
-        popupState.countdownTarget !== nextState.countdownTarget;
+        popupState.countdownTarget !== nextState.countdownTarget ||
+        popupState.countdownSeconds !== nextState.countdownSeconds;
 
       popupState = {
         ...nextState,
@@ -3495,8 +3653,10 @@
             text: popupState.text,
             isActive: popupState.isActive,
             durationSeconds: popupState.durationSeconds,
+            countdownMode: popupState.countdownMode,
             countdownEnabled: popupState.countdownEnabled,
-            countdownTarget: popupState.countdownTarget
+            countdownTarget: popupState.countdownTarget,
+            countdownSeconds: popupState.countdownSeconds
           })
         });
         let data = null;
@@ -4213,8 +4373,10 @@
           text: popup.text,
           isActive: popup.isActive,
           durationSeconds: popup.durationSeconds,
+          countdownMode: popup.countdownMode,
           countdownEnabled: popup.countdownEnabled,
-          countdownTarget: popup.countdownTarget
+          countdownTarget: popup.countdownTarget,
+          countdownSeconds: popup.countdownSeconds
         },
         slate: serialiseSlateState(),
         updatedAt: Date.now()
@@ -4752,35 +4914,80 @@
 
     if (el.popupCountdownTarget) {
       el.popupCountdownTarget.addEventListener('input', () => {
-        if (el.popupCountdownEnabled && el.popupCountdownEnabled.checked) {
+        if (
+          getCountdownModeFromInputs() === COUNTDOWN_MODE_TARGET &&
+          el.popupCountdownEnabled &&
+          el.popupCountdownEnabled.checked
+        ) {
           updatePopupPreview();
         }
       });
       el.popupCountdownTarget.addEventListener('change', () => {
-        if (el.popupCountdownEnabled && el.popupCountdownEnabled.checked) {
+        if (getCountdownModeFromInputs() === COUNTDOWN_MODE_TARGET) {
+          updatePopupPreview();
           queuePopupSave();
+        } else {
+          updateCountdownInputsDisabled();
         }
       });
     }
 
+    if (el.popupCountdownSeconds) {
+      el.popupCountdownSeconds.addEventListener('input', () => {
+        if (
+          getCountdownModeFromInputs() === COUNTDOWN_MODE_DURATION &&
+          el.popupCountdownEnabled &&
+          el.popupCountdownEnabled.checked
+        ) {
+          updatePopupPreview();
+        }
+      });
+      el.popupCountdownSeconds.addEventListener('change', () => {
+        updatePopupPreview();
+        queuePopupSave();
+      });
+    }
+
+    if (Array.isArray(el.popupCountdownModeInputs)) {
+      for (const input of el.popupCountdownModeInputs) {
+        if (!input) continue;
+        input.addEventListener('change', () => {
+          const mode = getCountdownModeFromInputs();
+          setCountdownModeInputs(mode);
+          updatePopupPreview();
+          updateCountdownInputsDisabled();
+          queuePopupSave();
+        });
+      }
+    }
+
     if (el.popupCountdownEnabled) {
       el.popupCountdownEnabled.addEventListener('change', () => {
+        const mode = getCountdownModeFromInputs();
         if (el.popupCountdownEnabled.checked) {
           if (!el.popupText.value.trim()) {
             el.popupCountdownEnabled.checked = false;
             toast('Enter popup text before enabling the countdown');
+            updateCountdownInputsDisabled();
             return;
           }
-          if (!el.popupCountdownTarget || !el.popupCountdownTarget.value) {
-            toast('Select a countdown target time');
+          if (mode === COUNTDOWN_MODE_TARGET) {
+            if (!el.popupCountdownTarget || !el.popupCountdownTarget.value) {
+              toast('Select a countdown target time');
+            }
+          } else {
+            const secondsValue = el.popupCountdownSeconds ? el.popupCountdownSeconds.value.trim() : '';
+            if (!secondsValue) {
+              toast('Enter countdown duration in seconds');
+            }
           }
         }
         updatePopupPreview();
-        if (el.popupCountdownTarget) {
-          el.popupCountdownTarget.disabled = popupSaveInFlight || !el.popupCountdownEnabled.checked;
-        }
-        const hasTarget = el.popupCountdownTarget && el.popupCountdownTarget.value;
-        if (!el.popupCountdownEnabled.checked || hasTarget) {
+        updateCountdownInputsDisabled();
+        const hasValue = mode === COUNTDOWN_MODE_DURATION
+          ? Number.isFinite(normaliseCountdownSeconds(el.popupCountdownSeconds ? el.popupCountdownSeconds.value.trim() : ''))
+          : !!(el.popupCountdownTarget && el.popupCountdownTarget.value);
+        if (!el.popupCountdownEnabled.checked || hasValue) {
           queuePopupSave();
         }
       });
@@ -4814,8 +5021,10 @@
         text: '',
         isActive: false,
         durationSeconds: null,
+        countdownMode: COUNTDOWN_MODE_TARGET,
         countdownEnabled: false,
         countdownTarget: null,
+        countdownSeconds: null,
         updatedAt: Date.now()
       };
       updatePopupMeta();

--- a/public/js/client-normalisers.js
+++ b/public/js/client-normalisers.js
@@ -61,8 +61,10 @@
     text: '',
     isActive: false,
     durationSeconds: null,
+    countdownMode: 'target',
     countdownEnabled: false,
     countdownTarget: null,
+    countdownSeconds: null,
     ...(sharedConfig.DEFAULT_POPUP || {})
   });
 
@@ -156,6 +158,21 @@
       return sharedUtils.clampSlateRotationSeconds(value, fallback);
     }
     return clampNumber(value, 4, 900, fallback, 0);
+  }
+
+  const COUNTDOWN_MODE_TARGET = 'target';
+  const COUNTDOWN_MODE_DURATION = 'duration';
+  const COUNTDOWN_MODES = new Set([COUNTDOWN_MODE_TARGET, COUNTDOWN_MODE_DURATION]);
+
+  function normaliseCountdownMode(value) {
+    const mode = String(value || '').toLowerCase();
+    return COUNTDOWN_MODES.has(mode) ? mode : COUNTDOWN_MODE_TARGET;
+  }
+
+  function normaliseCountdownSeconds(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= 0) return null;
+    return Math.max(1, Math.round(numeric));
   }
 
   function isSafeColour(value) {
@@ -296,8 +313,10 @@
       text: '',
       isActive: false,
       durationSeconds: null,
+      countdownMode: 'target',
       countdownEnabled: false,
       countdownTarget: null,
+      countdownSeconds: null,
       updatedAt: null
     };
 
@@ -310,20 +329,27 @@
     if (Number.isFinite(applyDefaults.durationSeconds) && applyDefaults.durationSeconds > 0) {
       result.durationSeconds = clampNumber(applyDefaults.durationSeconds, 1, maxDurationSeconds, null, 0);
     }
+    result.countdownMode = normaliseCountdownMode(applyDefaults.countdownMode);
+    if (Object.prototype.hasOwnProperty.call(applyDefaults, 'countdownSeconds')) {
+      const seconds = normaliseCountdownSeconds(applyDefaults.countdownSeconds);
+      if (seconds !== null) {
+        result.countdownSeconds = seconds;
+      }
+    }
     if (Number.isFinite(applyDefaults.countdownTarget)) {
       result.countdownTarget = Math.round(applyDefaults.countdownTarget);
     }
-    result.countdownEnabled = !!applyDefaults.countdownEnabled && Number.isFinite(result.countdownTarget) && !!result.text;
+    const defaultHasValue = result.countdownMode === COUNTDOWN_MODE_DURATION
+      ? Number.isFinite(result.countdownSeconds)
+      : Number.isFinite(result.countdownTarget);
+    result.countdownEnabled = !!applyDefaults.countdownEnabled && defaultHasValue && !!result.text;
     const defaultUpdatedAt = Number(applyDefaults.updatedAt ?? applyDefaults._updatedAt);
     if (Number.isFinite(defaultUpdatedAt)) {
       result.updatedAt = defaultUpdatedAt;
     }
 
     if (!data || typeof data !== 'object') {
-      if (!Number.isFinite(result.updatedAt)) {
-        result.updatedAt = Date.now();
-      }
-      return result;
+      data = {};
     }
 
     if (typeof data.text === 'string') {
@@ -343,8 +369,17 @@
       }
     }
 
+    if (typeof data.countdownMode === 'string') {
+      result.countdownMode = normaliseCountdownMode(data.countdownMode);
+    }
+
     if (Object.prototype.hasOwnProperty.call(data, 'countdownEnabled')) {
       result.countdownEnabled = !!data.countdownEnabled;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'countdownSeconds')) {
+      const seconds = normaliseCountdownSeconds(data.countdownSeconds);
+      result.countdownSeconds = seconds;
     }
 
     if (Object.prototype.hasOwnProperty.call(data, 'countdownTarget')) {
@@ -352,23 +387,48 @@
       result.countdownTarget = Number.isFinite(numeric) ? Math.round(numeric) : null;
     }
 
-    if (!result.text) {
-      result.isActive = false;
-      result.countdownEnabled = false;
-      result.countdownTarget = null;
-    }
-
-    if (!Number.isFinite(result.countdownTarget)) {
-      result.countdownTarget = null;
-      result.countdownEnabled = false;
-    } else {
-      result.countdownEnabled = result.countdownEnabled && !!result.text;
-    }
-
     const updatedAt = Number(data.updatedAt ?? data._updatedAt);
     result.updatedAt = Number.isFinite(updatedAt)
       ? updatedAt
       : (Number.isFinite(result.updatedAt) ? result.updatedAt : Date.now());
+
+    if (!result.text) {
+      result.isActive = false;
+      result.countdownEnabled = false;
+      result.countdownTarget = null;
+      result.countdownSeconds = null;
+    }
+
+    if (result.countdownMode === COUNTDOWN_MODE_DURATION) {
+      if (!Number.isFinite(result.countdownSeconds)) {
+        result.countdownSeconds = null;
+      }
+      if (Number.isFinite(result.countdownSeconds)) {
+        if (!Number.isFinite(result.countdownTarget)) {
+          result.countdownTarget = result.updatedAt + result.countdownSeconds * 1000;
+        }
+      } else {
+        result.countdownTarget = null;
+      }
+    } else {
+      result.countdownSeconds = null;
+      if (!Number.isFinite(result.countdownTarget)) {
+        result.countdownTarget = null;
+      }
+    }
+
+    const hasCountdownValue = result.countdownMode === COUNTDOWN_MODE_DURATION
+      ? Number.isFinite(result.countdownSeconds)
+      : Number.isFinite(result.countdownTarget);
+
+    if (!hasCountdownValue) {
+      result.countdownEnabled = false;
+      if (result.countdownMode === COUNTDOWN_MODE_DURATION) {
+        result.countdownTarget = null;
+      }
+    } else {
+      result.countdownEnabled = !!result.countdownEnabled && !!result.text;
+    }
 
     return result;
   }

--- a/public/js/shared-config.js
+++ b/public/js/shared-config.js
@@ -36,8 +36,10 @@
     text: '',
     isActive: false,
     durationSeconds: null,
+    countdownMode: 'target',
     countdownEnabled: false,
-    countdownTarget: null
+    countdownTarget: null,
+    countdownSeconds: null
   });
 
   const DEFAULT_SLATE = Object.freeze({

--- a/public/output.html
+++ b/public/output.html
@@ -751,11 +751,17 @@
       text: '',
       isActive: false,
       durationSeconds: null,
+      countdownMode: 'target',
       countdownEnabled: false,
       countdownTarget: null,
+      countdownSeconds: null,
       ...(sharedConfig.DEFAULT_POPUP || {}),
       updatedAt: null
     };
+
+    const COUNTDOWN_MODE_TARGET = 'target';
+    const COUNTDOWN_MODE_DURATION = 'duration';
+    const COUNTDOWN_MODES = new Set([COUNTDOWN_MODE_TARGET, COUNTDOWN_MODE_DURATION]);
 
     const DEFAULT_SLATE_SOURCE = {
       isEnabled: true,
@@ -845,6 +851,17 @@
       return THEME_CLASSNAMES.includes(`ticker--${theme}`) ? theme : null;
     }
 
+    function normaliseCountdownMode(value) {
+      const mode = String(value || '').toLowerCase();
+      return COUNTDOWN_MODES.has(mode) ? mode : COUNTDOWN_MODE_TARGET;
+    }
+
+    function normaliseCountdownSeconds(value) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric <= 0) return null;
+      return Math.max(1, Math.round(numeric));
+    }
+
     function normalisePopupPayload(data) {
       const text = typeof data?.text === 'string' ? data.text.trim().slice(0, 280) : '';
       const isActive = !!data?.isActive && !!text;
@@ -852,17 +869,34 @@
       const durationSeconds = Number.isFinite(durationRaw) && durationRaw > 0
         ? Math.max(1, Math.min(MAX_POPUP_SECONDS, Math.round(durationRaw)))
         : null;
+      const countdownMode = normaliseCountdownMode(data?.countdownMode);
+      const seconds = normaliseCountdownSeconds(data?.countdownSeconds);
       const countdownTargetRaw = Number(data?.countdownTarget);
-      const countdownTarget = Number.isFinite(countdownTargetRaw) ? Math.round(countdownTargetRaw) : null;
-      const countdownEnabled = !!data?.countdownEnabled && !!text && countdownTarget !== null;
+      let countdownTarget = Number.isFinite(countdownTargetRaw) ? Math.round(countdownTargetRaw) : null;
       const updatedAt = Number(data?._updatedAt ?? data?.updatedAt);
+      const resolvedUpdatedAt = Number.isFinite(updatedAt) ? updatedAt : Date.now();
+      if (countdownMode === COUNTDOWN_MODE_DURATION) {
+        if (Number.isFinite(seconds)) {
+          if (!Number.isFinite(countdownTarget)) {
+            countdownTarget = resolvedUpdatedAt + seconds * 1000;
+          }
+        } else {
+          countdownTarget = null;
+        }
+      }
+      const hasCountdownValue = countdownMode === COUNTDOWN_MODE_DURATION
+        ? Number.isFinite(seconds)
+        : countdownTarget !== null;
+      const countdownEnabled = !!data?.countdownEnabled && !!text && hasCountdownValue;
       return {
         text,
         isActive,
         durationSeconds,
+        countdownMode,
         countdownEnabled,
         countdownTarget,
-        updatedAt: Number.isFinite(updatedAt) ? updatedAt : Date.now()
+        countdownSeconds: countdownMode === COUNTDOWN_MODE_DURATION && Number.isFinite(seconds) ? seconds : null,
+        updatedAt: resolvedUpdatedAt
       };
     }
 

--- a/server.js
+++ b/server.js
@@ -91,8 +91,10 @@ const BASE_DEFAULT_POPUP = CONFIG_DEFAULT_POPUP
       text: '',
       isActive: false,
       durationSeconds: null,
+      countdownMode: 'target',
       countdownEnabled: false,
-      countdownTarget: null
+      countdownTarget: null,
+      countdownSeconds: null
     };
 
 const BASE_DEFAULT_SLATE_SOURCE = CONFIG_DEFAULT_SLATE
@@ -265,23 +267,22 @@ app.post('/popup/state', (req, res) => {
     if (Object.prototype.hasOwnProperty.call(update, 'durationSeconds')) {
       state.popup.durationSeconds = update.durationSeconds;
     }
+    if (Object.prototype.hasOwnProperty.call(update, 'countdownMode')) {
+      state.popup.countdownMode = update.countdownMode;
+    }
     if (Object.prototype.hasOwnProperty.call(update, 'countdownEnabled')) {
       state.popup.countdownEnabled = update.countdownEnabled;
+    }
+    if (Object.prototype.hasOwnProperty.call(update, 'countdownSeconds')) {
+      state.popup.countdownSeconds = update.countdownSeconds;
     }
     if (Object.prototype.hasOwnProperty.call(update, 'countdownTarget')) {
       state.popup.countdownTarget = update.countdownTarget;
     }
-    if (!state.popup.text.trim()) {
-      state.popup.text = '';
-      state.popup.isActive = false;
-      state.popup.countdownEnabled = false;
-      state.popup.countdownTarget = null;
-    }
-    if (!state.popup.countdownEnabled || !Number.isFinite(state.popup.countdownTarget)) {
-      state.popup.countdownEnabled = false;
-      state.popup.countdownTarget = null;
-    }
-    state.popup._updatedAt = Date.now();
+    state.popup.countdownMode = normaliseCountdownMode(state.popup.countdownMode);
+    const now = Date.now();
+    state.popup._updatedAt = now;
+    reconcilePopupState(state.popup, now);
     schedulePopupAutoDismiss();
     schedulePersist();
     broadcast('popup', state.popup);
@@ -519,20 +520,52 @@ function sanitisePopupInput(input) {
         result.durationSeconds = null;
       }
     }
+    if (typeof input.countdownMode === 'string') {
+      result.countdownMode = normaliseCountdownMode(input.countdownMode);
+    }
     if (Object.prototype.hasOwnProperty.call(input, 'countdownEnabled')) {
       result.countdownEnabled = !!input.countdownEnabled;
+    }
+    if (Object.prototype.hasOwnProperty.call(input, 'countdownSeconds')) {
+      result.countdownSeconds = normaliseCountdownSeconds(input.countdownSeconds);
     }
     if (Object.prototype.hasOwnProperty.call(input, 'countdownTarget')) {
       result.countdownTarget = normaliseCountdownTarget(input.countdownTarget);
     }
   }
+  result.countdownMode = normaliseCountdownMode(result.countdownMode);
   if (!Number.isFinite(result.countdownTarget)) {
     result.countdownTarget = null;
   }
-  if (!result.countdownTarget) {
+  if (!Number.isFinite(result.countdownSeconds)) {
+    result.countdownSeconds = null;
+  }
+  const hasValue = result.countdownMode === 'duration'
+    ? Number.isFinite(result.countdownSeconds)
+    : Number.isFinite(result.countdownTarget);
+  if (!hasValue) {
     result.countdownEnabled = false;
+    if (result.countdownMode === 'duration') {
+      result.countdownTarget = null;
+    }
   }
   return result;
+}
+
+function normaliseCountdownMode(value) {
+  const mode = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return mode === 'duration' ? 'duration' : 'target';
+}
+
+function normaliseCountdownSeconds(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
+  }
+  return Math.max(1, Math.round(numeric));
 }
 
 function normaliseCountdownTarget(value) {
@@ -551,6 +584,44 @@ function normaliseCountdownTarget(value) {
   const parsed = new Date(trimmed);
   const ms = parsed.getTime();
   return Number.isNaN(ms) ? null : ms;
+}
+
+function reconcilePopupState(popup, timestamp = Date.now()) {
+  if (!popup || typeof popup !== 'object') return popup;
+  popup.countdownMode = normaliseCountdownMode(popup.countdownMode);
+  const text = typeof popup.text === 'string' ? popup.text.trim() : '';
+  if (!text) {
+    popup.text = '';
+    popup.isActive = false;
+    popup.countdownEnabled = false;
+    popup.countdownTarget = null;
+    popup.countdownSeconds = null;
+    return popup;
+  }
+  popup.text = text;
+  if (popup.countdownMode === 'duration') {
+    const seconds = normaliseCountdownSeconds(popup.countdownSeconds);
+    popup.countdownSeconds = seconds;
+    if (!popup.countdownEnabled || !Number.isFinite(seconds)) {
+      popup.countdownEnabled = false;
+      popup.countdownTarget = null;
+    } else {
+      popup.countdownTarget = timestamp + seconds * 1000;
+    }
+  } else {
+    popup.countdownSeconds = null;
+    popup.countdownTarget = normaliseCountdownTarget(popup.countdownTarget);
+    if (!Number.isFinite(popup.countdownTarget)) {
+      popup.countdownTarget = null;
+    }
+  }
+  if (popup.countdownEnabled) {
+    popup.countdownEnabled = !!popup.text;
+    if (!popup.countdownEnabled && popup.countdownMode === 'duration') {
+      popup.countdownTarget = null;
+    }
+  }
+  return popup;
 }
 
 function clearPopupAutoDismiss() {
@@ -891,12 +962,7 @@ function applyScene(scene) {
       ...popup,
       _updatedAt: now
     };
-    if (!state.popup.text.trim()) {
-      state.popup.text = '';
-      state.popup.isActive = false;
-      state.popup.countdownEnabled = false;
-      state.popup.countdownTarget = null;
-    }
+    reconcilePopupState(state.popup, now);
     schedulePopupAutoDismiss();
     popupChanged = true;
   }
@@ -1013,12 +1079,7 @@ function hydrateState(partial, target = state, options = {}) {
       ...popup,
       _updatedAt: Number.isFinite(partial.popup._updatedAt) ? partial.popup._updatedAt : Date.now()
     };
-    if (!target.popup.text || !target.popup.text.trim()) {
-      target.popup.text = '';
-      target.popup.isActive = false;
-      target.popup.countdownEnabled = false;
-      target.popup.countdownTarget = null;
-    }
+    reconcilePopupState(target.popup, target.popup._updatedAt || Date.now());
   }
 
   if (partial.slate && typeof partial.slate === 'object') {
@@ -1048,8 +1109,12 @@ function replaceState(nextState) {
   state.presets = Array.isArray(nextState.presets) ? nextState.presets : [];
   state.scenes = Array.isArray(nextState.scenes) ? nextState.scenes : [];
   if (nextState.overlay) state.overlay = nextState.overlay;
-  if (nextState.popup) state.popup = nextState.popup;
+  if (nextState.popup) {
+    state.popup = nextState.popup;
+    reconcilePopupState(state.popup, state.popup && Number.isFinite(state.popup._updatedAt) ? state.popup._updatedAt : Date.now());
+  }
   if (nextState.slate) state.slate = nextState.slate;
+  schedulePopupAutoDismiss();
 }
 
 async function loadStateFromDisk() {

--- a/ticker-state.json
+++ b/ticker-state.json
@@ -35,8 +35,10 @@
     "text": "Silent Hill f - Deep Dive / Analysis w/ Moose",
     "isActive": true,
     "durationSeconds": null,
+    "countdownMode": "target",
     "countdownEnabled": false,
     "countdownTarget": null,
+    "countdownSeconds": null,
     "_updatedAt": 1758647615533
   },
   "slate": {


### PR DESCRIPTION
## Summary
- add a mode toggle and seconds input so popup countdowns can target a time or a duration
- track the selected countdown mode and seconds throughout the dashboard, normalisers, and server persistence
- update the overlay client to honour the new countdown mode and compute live targets for duration-based timers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60333cecc83218416329c346d9eec