### PR TITLE
Document shared config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,26 @@ Set the following environment variables before starting `server.js` to change wh
 | `TICKER_STATE_FILE` | Path to the JSON file used to persist combined ticker/popup/scene state. | `<repo>/ticker-state.json` |
 
 Both variables accept relative paths, which will be resolved against the current working directory when the server boots.
+
+For default overlay, popup, and slate behavior without rebuilding the app, edit `public/js/shared-config.js`. This file exports shared constants that power the client UI, including:
+
+- `DEFAULT_OVERLAY.label` – the human-friendly name shown on the overlay when no queue item is active.
+- `DEFAULT_OVERLAY.accent` – the hex/rgb color used for accent elements across the overlay and popup.
+- `DEFAULT_OVERLAY.theme` – controls the base light/dark styling that downstream components apply.
+- `DEFAULT_HIGHLIGHTS` – an array of highlight presets surfaced in the dashboard for quick selection.
+
+For example, to customize these defaults you can tweak the exported values directly:
+
+```js
+export const DEFAULT_OVERLAY = {
+  label: "My Stream",
+  accent: "#00aaff",
+  theme: "dark",
+};
+
+export const DEFAULT_HIGHLIGHTS = [
+  { title: "Breaking News", color: "#ff3366" },
+];
+```
+
+Technically minded users can fork the repository, adjust `public/js/shared-config.js`, and redeploy their variant. Loading these settings from JSON at runtime is on the roadmap as an optional enhancement for future releases.


### PR DESCRIPTION
## Summary
- note that default overlay, popup, and slate settings can be edited in public/js/shared-config.js
- describe key exported fields and show a code sample for customizing them
- call out that advanced users can fork/modify the JS file today with optional future JSON loading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60a41e67483218d5fa4c758cf7fba