### PR TITLE
Add optional verbose logging for state updates

### DIFF
--- a/server.js
+++ b/server.js
@@ -158,6 +158,59 @@ function createInitialState() {
   };
 }
 
+const ENABLE_SERVER_LOGS = /^true$/i.test(process.env.TICKER_VERBOSE_LOGS || process.env.ENABLE_TICKER_LOGS || '');
+
+function safeTruncate(value, max = 160) {
+  if (typeof value !== 'string') return value;
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}…`;
+}
+
+function sanitiseForLog(value, depth = 0) {
+  if (value === null || value === undefined) return value;
+  const type = typeof value;
+  if (type === 'string') return safeTruncate(value);
+  if (type === 'number' || type === 'boolean') return value;
+  if (type === 'function') return '[function]';
+  if (Array.isArray(value)) {
+    if (depth >= 1) return `Array(${value.length})`;
+    return value.slice(0, 5).map(item => sanitiseForLog(item, depth + 1));
+  }
+  if (type === 'object') {
+    if (depth >= 1) return '[Object]';
+    const entries = Object.entries(value).slice(0, 10);
+    return entries.reduce((acc, [key, val]) => {
+      acc[key] = sanitiseForLog(val, depth + 1);
+      return acc;
+    }, {});
+  }
+  return `[${type}]`;
+}
+
+function logInfo(message, context) {
+  if (!ENABLE_SERVER_LOGS) return;
+  if (context !== undefined) {
+    console.info(message, sanitiseForLog(context));
+  } else {
+    console.info(message);
+  }
+}
+
+function logWarning(message, context) {
+  if (!ENABLE_SERVER_LOGS) return;
+  console.warn(message, sanitiseForLog(context));
+}
+
+function logError(message, context) {
+  if (!ENABLE_SERVER_LOGS) return;
+  console.error(message, sanitiseForLog(context));
+}
+
+function sanitiseUserAgent(value) {
+  if (typeof value !== 'string') return undefined;
+  return safeTruncate(value, 200);
+}
+
 const app = express();
 app.use(cors());
 app.use(express.json({ limit: '256kb' }));
@@ -209,6 +262,10 @@ app.get('/ticker/stream', (req, res) => {
   res.write('retry: 2000\n\n');
 
   sseClients.add(res);
+  logInfo('[SSE] client connected', {
+    ip: req.ip,
+    userAgent: sanitiseUserAgent(req.headers['user-agent'])
+  });
   sendInitialState(res);
 
   const heartbeat = setInterval(() => {
@@ -223,6 +280,10 @@ app.get('/ticker/stream', (req, res) => {
   req.on('close', () => {
     clearInterval(heartbeat);
     sseClients.delete(res);
+    logInfo('[SSE] client disconnected', {
+      ip: req.ip,
+      userAgent: sanitiseUserAgent(req.headers['user-agent'])
+    });
   });
 });
 
@@ -242,8 +303,18 @@ app.post('/ticker/state', (req, res) => {
     state.ticker._updatedAt = Date.now();
     schedulePersist();
     broadcast('ticker', state.ticker);
+    logInfo('[Ticker] state updated', {
+      isActive: state.ticker.isActive,
+      messageCount: state.ticker.messages.length,
+      displayDuration: state.ticker.displayDuration,
+      intervalBetween: state.ticker.intervalBetween
+    });
     res.json({ ok: true, state: state.ticker });
   } catch (e) {
+    logWarning('[Ticker] state update failed', {
+      error: e && e.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: e.message || 'Invalid ticker payload' });
   }
 });
@@ -285,8 +356,17 @@ app.post('/popup/state', (req, res) => {
     schedulePopupAutoDismiss();
     schedulePersist();
     broadcast('popup', state.popup);
+    logInfo('[Popup] state updated', {
+      isActive: state.popup.isActive,
+      countdownEnabled: state.popup.countdownEnabled,
+      textPreview: safeTruncate(state.popup.text || '', 80)
+    });
     res.json({ ok: true, popup: state.popup });
   } catch (e) {
+    logWarning('[Popup] state update failed', {
+      error: e && e.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: e.message });
   }
 });
@@ -302,8 +382,17 @@ app.post('/ticker/overlay', (req, res) => {
     state.overlay = { ...state.overlay, ...overlay, _updatedAt: Date.now() };
     schedulePersist();
     broadcast('overlay', state.overlay);
+    logInfo('[Overlay] state updated', {
+      label: state.overlay.label,
+      theme: state.overlay.theme,
+      accent: state.overlay.accent
+    });
     res.json({ ok: true, overlay: state.overlay });
   } catch (e) {
+    logWarning('[Overlay] state update failed', {
+      error: e && e.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: e.message });
   }
 });
@@ -328,8 +417,18 @@ app.post('/slate/state', (req, res) => {
     };
     schedulePersist();
     broadcast('slate', state.slate);
+    logInfo('[Slate] state updated', {
+      isEnabled: state.slate.isEnabled,
+      rotationSeconds: state.slate.rotationSeconds,
+      notesCount: Array.isArray(state.slate.notes) ? state.slate.notes.length : 0,
+      nextTitle: safeTruncate(state.slate.nextTitle || '', 80)
+    });
     res.json({ ok: true, slate: state.slate });
   } catch (e) {
+    logWarning('[Slate] state update failed', {
+      error: e && e.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: e.message || 'Invalid slate payload' });
   }
 });
@@ -353,8 +452,16 @@ app.post('/brb/state', (req, res) => {
     state.brb._updatedAt = Date.now();
     schedulePersist();
     broadcast('brb', state.brb);
+    logInfo('[BRB] state updated', {
+      isActive: state.brb.isActive,
+      textPreview: safeTruncate(state.brb.text || '', 80)
+    });
     res.json({ ok: true, state: state.brb });
   } catch (e) {
+    logWarning('[BRB] state update failed', {
+      error: e && e.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: e.message });
   }
 });
@@ -370,8 +477,15 @@ app.post('/ticker/presets', (req, res) => {
     state.presets = sanitisePresetList(presets, { strict: true });
     schedulePersist();
     broadcast('presets', state.presets);
+    logInfo('[Presets] list updated', {
+      count: Array.isArray(state.presets) ? state.presets.length : 0
+    });
     res.json({ ok: true, presets: state.presets });
   } catch (e) {
+    logWarning('[Presets] update failed', {
+      error: e && e.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: e.message });
   }
 });
@@ -387,8 +501,15 @@ app.post('/ticker/scenes', (req, res) => {
     state.scenes = sanitiseSceneList(scenes, { strict: true });
     schedulePersist();
     broadcast('scenes', state.scenes);
+    logInfo('[Scenes] list updated', {
+      count: Array.isArray(state.scenes) ? state.scenes.length : 0
+    });
     res.json({ ok: true, scenes: state.scenes });
   } catch (e) {
+    logWarning('[Scenes] update failed', {
+      error: e && e.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: e.message });
   }
 });
@@ -402,8 +523,13 @@ app.post('/ticker/scenes/apply', (req, res) => {
     }
     const result = applyScene(scene);
     schedulePersist();
+    logInfo('[Scenes] apply', { sceneId });
     res.json({ ok: true, sceneId, ...result });
   } catch (e) {
+    logWarning('[Scenes] apply failed', {
+      error: e && e.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: e.message });
   }
 });
@@ -446,6 +572,10 @@ app.post('/ticker/state/import', (req, res) => {
 
     res.json({ ok: true, state });
   } catch (err) {
+    logError('[State] import failed', {
+      error: err && err.message,
+      payload: req.body
+    });
     res.status(400).json({ ok: false, error: err.message || 'Invalid state import payload' });
   }
 });


### PR DESCRIPTION
## Summary
- add an environment-gated logging helper for verbose server diagnostics
- log SSE connections and successful entity updates with relevant metadata
- surface sanitised payload details in warning/error paths for easier debugging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60a3a099c83219159ed366c70398a