### PR TITLE
Centralize overlay theme sources

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1576,6 +1576,7 @@
       isSafeCssColor: sharedIsSafeCssColor
     } = window.TickerShared || {};
 
+    const sharedConfigWindow = window.SharedConfig || {};
     const normaliserExports = window.TickerClientNormalisers || {};
     const {
       DEFAULT_OVERLAY: BASE_DEFAULT_OVERLAY,
@@ -1599,6 +1600,20 @@
       sanitiseMessages
     } = normaliserExports;
 
+    function normaliseThemeList(list) {
+      if (!Array.isArray(list)) return [];
+      const seen = new Set();
+      const normalised = [];
+      for (const entry of list) {
+        if (typeof entry !== 'string') continue;
+        const trimmed = entry.trim().toLowerCase();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        normalised.push(trimmed);
+      }
+      return normalised;
+    }
+
     const STORAGE_KEY = 'ticker-dashboard-v3';
     const MAX_MESSAGES = EXPORTED_MAX_MESSAGES || 50;
     const MAX_MESSAGE_LENGTH = EXPORTED_MAX_MESSAGE_LENGTH || 280;
@@ -1613,8 +1628,8 @@
     const THEME_OPTIONS = Array.isArray(BASE_THEME_OPTIONS) && BASE_THEME_OPTIONS.length
         ? BASE_THEME_OPTIONS.slice()
         : (Array.isArray(OVERLAY_THEMES) && OVERLAY_THEMES.length
-            ? OVERLAY_THEMES
-            : ['midnight-glass', 'aurora-night', 'nexus-grid', 'zen-flow', 'duotone-fusion']);
+            ? OVERLAY_THEMES.slice()
+            : normaliseThemeList(sharedConfigWindow.OVERLAY_THEMES));
     const THEME_CLASSNAMES = THEME_OPTIONS.map(theme => `ticker--${theme}`);
     const MAX_PRESET_NAME_LENGTH = 80;
     const MAX_SCENE_NAME_LENGTH = 80;

--- a/public/js/client-normalisers.js
+++ b/public/js/client-normalisers.js
@@ -12,14 +12,6 @@
     root.TickerClientNormalisers = exports;
   }
 })(typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this, function (sharedUtils = {}, sharedConfig = {}) {
-  const FALLBACK_THEMES = [
-    'midnight-glass',
-    'aurora-night',
-    'nexus-grid',
-    'zen-flow',
-    'duotone-fusion'
-  ];
-
   const {
     MAX_TICKER_MESSAGES: SHARED_MAX_TICKER_MESSAGES,
     MAX_TICKER_MESSAGE_LENGTH: SHARED_MAX_MESSAGE_LENGTH,
@@ -53,9 +45,22 @@
     ? SHARED_MAX_SLATE_NOTES
     : 6;
 
-  const themeOptions = Array.isArray(sharedUtils.OVERLAY_THEMES) && sharedUtils.OVERLAY_THEMES.length
-    ? sharedUtils.OVERLAY_THEMES.slice()
-    : FALLBACK_THEMES.slice();
+  const themeOptions = (() => {
+    if (Array.isArray(sharedUtils.OVERLAY_THEMES) && sharedUtils.OVERLAY_THEMES.length) {
+      return sharedUtils.OVERLAY_THEMES.slice();
+    }
+    if (Array.isArray(sharedConfig.OVERLAY_THEMES) && sharedConfig.OVERLAY_THEMES.length) {
+      const seen = new Set();
+      return sharedConfig.OVERLAY_THEMES
+        .map(entry => (typeof entry === 'string' ? entry.trim().toLowerCase() : ''))
+        .filter(theme => {
+          if (!theme || seen.has(theme)) return false;
+          seen.add(theme);
+          return true;
+        });
+    }
+    return [];
+  })();
   const themeSet = new Set(themeOptions);
 
   const defaultHighlights = Array.isArray(sharedConfig.DEFAULT_HIGHLIGHTS) && sharedConfig.DEFAULT_HIGHLIGHTS.length

--- a/public/js/shared-config.js
+++ b/public/js/shared-config.js
@@ -18,6 +18,14 @@
 
   const DEFAULT_HIGHLIGHT_STRING = DEFAULT_HIGHLIGHTS.join(', ');
 
+  const OVERLAY_THEMES = Object.freeze([
+    'midnight-glass',
+    'aurora-night',
+    'nexus-grid',
+    'zen-flow',
+    'duotone-fusion'
+  ]);
+
   const DEFAULT_OVERLAY = Object.freeze({
     label: 'LIVE',
     accent: '#38bdf8',
@@ -57,6 +65,7 @@
   });
 
   return {
+    OVERLAY_THEMES,
     DEFAULT_OVERLAY,
     DEFAULT_POPUP,
     DEFAULT_SLATE,

--- a/public/output.html
+++ b/public/output.html
@@ -766,6 +766,20 @@
     };
 
     const sharedConfig = window.SharedConfig || {};
+
+    function normaliseThemeList(list) {
+      if (!Array.isArray(list)) return [];
+      const seen = new Set();
+      const normalised = [];
+      for (const entry of list) {
+        if (typeof entry !== 'string') continue;
+        const trimmed = entry.trim().toLowerCase();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        normalised.push(trimmed);
+      }
+      return normalised;
+    }
     const DEFAULT_HIGHLIGHTS = Array.isArray(sharedConfig.DEFAULT_HIGHLIGHTS) && sharedConfig.DEFAULT_HIGHLIGHTS.length
       ? sharedConfig.DEFAULT_HIGHLIGHTS.slice()
       : ['live', 'breaking', 'alert', 'update', 'tonight', 'today'];
@@ -780,7 +794,10 @@
     const MAX_SLATE_TEXT_LENGTH = 200;
     const MAX_SLATE_NOTES = 6;
     const HIDE_TRANSITION_FALLBACK_MS = 700;
-    const THEME_CLASSNAMES = (Array.isArray(OVERLAY_THEMES) ? OVERLAY_THEMES : ['midnight-glass', 'aurora-night', 'nexus-grid', 'zen-flow', 'duotone-fusion']).map(theme => `ticker--${theme}`);
+    const themeOptions = Array.isArray(OVERLAY_THEMES) && OVERLAY_THEMES.length
+      ? OVERLAY_THEMES.slice()
+      : normaliseThemeList(sharedConfig.OVERLAY_THEMES);
+    const THEME_CLASSNAMES = themeOptions.map(theme => `ticker--${theme}`);
 
     const DEFAULT_OVERLAY = {
       label: 'LIVE',


### PR DESCRIPTION
## Summary
- add the canonical overlay theme list to `shared-config.js`
- update shared utilities and client normalisers to consume the shared theme list
- ensure dashboard and output templates reference the shared theme options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60a3920448321b6bfd5b120ee7a4a