### PR TITLE
Add env overrides for default overlay styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,9 @@ Set the following environment variables before starting `server.js` to change wh
 | --- | --- | --- |
 | `TICKER_DIR` | Directory served at `/ticker` for dashboard and overlay assets. | `<repo>/public` |
 | `TICKER_STATE_FILE` | Path to the JSON file used to persist combined ticker/popup/scene state. | `<repo>/ticker-state.json` |
+| `TICKER_DEFAULT_LABEL` | Override the default overlay label text. | `LIVE` |
+| `TICKER_DEFAULT_ACCENT` | Override the default overlay accent colour (must be a valid CSS colour). | `#38bdf8` |
+| `TICKER_DEFAULT_ACCENT_SECONDARY` | Override the secondary accent colour (must be a valid CSS colour). | `#f472b6` |
+| `TICKER_DEFAULT_THEME` | Override the default overlay theme (must be one of the configured themes). | `midnight-glass` |
 
-Both variables accept relative paths, which will be resolved against the current working directory when the server boots.
+The path variables accept relative paths, which will be resolved against the current working directory when the server boots.

--- a/server.js
+++ b/server.js
@@ -69,7 +69,41 @@ const DEFAULT_HIGHLIGHT_STRING = typeof CONFIG_DEFAULT_HIGHLIGHT_STRING === 'str
   ? CONFIG_DEFAULT_HIGHLIGHT_STRING
   : DEFAULT_HIGHLIGHTS.join(',');
 
-const BASE_DEFAULT_OVERLAY = CONFIG_DEFAULT_OVERLAY
+const ENV_DEFAULT_OVERLAY_OVERRIDES = (() => {
+  const overrides = {};
+
+  const rawLabel = process.env.TICKER_DEFAULT_LABEL;
+  if (typeof rawLabel === 'string') {
+    const trimmed = rawLabel.trim().slice(0, 48);
+    if (trimmed) overrides.label = trimmed;
+  }
+
+  const rawAccent = process.env.TICKER_DEFAULT_ACCENT;
+  if (typeof rawAccent === 'string') {
+    const trimmedAccent = rawAccent.trim();
+    if (trimmedAccent && trimmedAccent.length <= 64 && isSafeCssColor(trimmedAccent)) {
+      overrides.accent = trimmedAccent;
+    }
+  }
+
+  const rawAccentSecondary = process.env.TICKER_DEFAULT_ACCENT_SECONDARY;
+  if (typeof rawAccentSecondary === 'string') {
+    const trimmedSecondary = rawAccentSecondary.trim();
+    if (trimmedSecondary && trimmedSecondary.length <= 64 && isSafeCssColor(trimmedSecondary)) {
+      overrides.accentSecondary = trimmedSecondary;
+    }
+  }
+
+  const rawTheme = process.env.TICKER_DEFAULT_THEME;
+  if (typeof rawTheme === 'string') {
+    const theme = normaliseTheme(rawTheme);
+    if (theme) overrides.theme = theme;
+  }
+
+  return overrides;
+})();
+
+const BASE_DEFAULT_OVERLAY_SOURCE = CONFIG_DEFAULT_OVERLAY
   ? { ...CONFIG_DEFAULT_OVERLAY }
   : {
       label: 'LIVE',
@@ -84,6 +118,11 @@ const BASE_DEFAULT_OVERLAY = CONFIG_DEFAULT_OVERLAY
       sparkle: true,
       theme: 'midnight-glass'
     };
+
+const BASE_DEFAULT_OVERLAY = {
+  ...BASE_DEFAULT_OVERLAY_SOURCE,
+  ...ENV_DEFAULT_OVERLAY_OVERRIDES
+};
 
 const BASE_DEFAULT_POPUP = CONFIG_DEFAULT_POPUP
   ? { ...CONFIG_DEFAULT_POPUP }


### PR DESCRIPTION
## Summary
- allow default overlay label, accents, and theme to be overridden via environment variables with validation
- document the new environment variables in the configuration table

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60a42cf388321b039ed896f3f0e17