### PR TITLE
Add rotating backups for ticker state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,17 @@ Set the following environment variables before starting `server.js` to change wh
 | --- | --- | --- |
 | `TICKER_DIR` | Directory served at `/ticker` for dashboard and overlay assets. | `<repo>/public` |
 | `TICKER_STATE_FILE` | Path to the JSON file used to persist combined ticker/popup/scene state. | `<repo>/ticker-state.json` |
+| `TICKER_STATE_BACKUPS` | Number of historical copies of the state file to keep (rotated as `ticker-state.json.bakN`). | `5` |
 
-Both variables accept relative paths, which will be resolved against the current working directory when the server boots.
+`TICKER_DIR` and `TICKER_STATE_FILE` accept relative paths, which will be resolved against the current working directory when the server boots.
+
+## Restoring from a backup
+
+Every successful persist rotates the current `ticker-state.json` into a numbered backup (for example, `ticker-state.json.bak1`) before the new state is promoted. To restore from one of these backups:
+
+1. Stop the server so it does not rewrite the state file while you recover.
+2. Pick the backup you want to restore (higher numbers are older snapshots) and copy it back into place, e.g.:
+   ```bash
+   cp ticker-state.json.bak1 ticker-state.json
+   ```
+3. Restart the server; it will load the restored state on boot.

--- a/server.js
+++ b/server.js
@@ -59,6 +59,12 @@ const PUBLIC_TICKER = path.resolve(TICKER_DIR_INPUT);
 const DEFAULT_STATE_FILE = path.join(__dirname, 'ticker-state.json');
 const STATE_FILE_INPUT = process.env.TICKER_STATE_FILE || DEFAULT_STATE_FILE;
 const STATE_FILE = path.resolve(STATE_FILE_INPUT);
+const STATE_BACKUP_LIMIT = (() => {
+  const raw = Number(process.env.TICKER_STATE_BACKUPS);
+  if (!Number.isFinite(raw)) return 5;
+  const clamped = Math.floor(raw);
+  return clamped > 0 ? clamped : 0;
+})();
 
 const PERSIST_DEBOUNCE_MS = 150;
 const FALLBACK_HIGHLIGHTS = ['live', 'breaking', 'alert', 'update', 'tonight', 'today'];
@@ -1050,6 +1056,7 @@ async function writeStateToDisk() {
   const tmpFile = `${STATE_FILE}.tmp`;
   try {
     await fsp.writeFile(tmpFile, payload, 'utf8');
+    await rotateStateBackups();
     await fsp.rename(tmpFile, STATE_FILE);
   } catch (err) {
     try {
@@ -1061,6 +1068,47 @@ async function writeStateToDisk() {
     }
     throw err;
   }
+}
+
+async function rotateStateBackups() {
+  if (STATE_BACKUP_LIMIT <= 0) return false;
+
+  let rotatedPrimary = false;
+
+  for (let index = STATE_BACKUP_LIMIT; index >= 1; index -= 1) {
+    const source = index === 1 ? STATE_FILE : `${STATE_FILE}.bak${index - 1}`;
+    const target = `${STATE_FILE}.bak${index}`;
+
+    try {
+      await fsp.access(source);
+    } catch (accessErr) {
+      if (accessErr && accessErr.code !== 'ENOENT') {
+        throw accessErr;
+      }
+      continue;
+    }
+
+    try {
+      await fsp.unlink(target);
+    } catch (unlinkErr) {
+      if (unlinkErr && unlinkErr.code !== 'ENOENT') {
+        console.warn(`[state] failed to remove old backup ${target}:`, unlinkErr);
+        throw unlinkErr;
+      }
+    }
+
+    await fsp.rename(source, target);
+
+    if (index === 1) {
+      rotatedPrimary = true;
+    }
+  }
+
+  if (rotatedPrimary) {
+    console.log(`[state] rotated backups (keeping last ${STATE_BACKUP_LIMIT})`);
+  }
+
+  return rotatedPrimary;
 }
 
 loadStateFromDisk().finally(() => {


### PR DESCRIPTION
## Summary
- add configurable retention and rotation for ticker state backups when persisting state
- log backup rotation and document recovery steps in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60a4343608321b57e7cc091fc2a1d