### PR TITLE
Adjust scene overlay serialisation options

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1757,9 +1757,11 @@
     const buildSceneOverlayPayload = serialiseOverlayForSceneImpl
       ? (overlayPrefs = {}) => serialiseOverlayForSceneImpl(
           overlayPrefs && typeof overlayPrefs === 'object' ? overlayPrefs : {},
-          normaliseOverlayData,
-          SCENE_OVERLAY_KEYS,
-          { includeEmptyStrings: false }
+          {
+            normaliseOverlayData,
+            overlayKeys: SCENE_OVERLAY_KEYS,
+            includeEmptyStrings: false
+          }
         )
       : (overlayPrefs = {}) => {
           const source = overlayPrefs && typeof overlayPrefs === 'object' ? overlayPrefs : {};
@@ -4491,7 +4493,11 @@
       const allowedKeys = SCENE_OVERLAY_KEYS || [];
 
       if (serialiseOverlayForSceneImpl) {
-        const serialised = serialiseOverlayForSceneImpl(prefs, { keys: allowedKeys });
+        const serialised = serialiseOverlayForSceneImpl(prefs, {
+          normaliseOverlayData,
+          overlayKeys: allowedKeys,
+          includeEmptyStrings: false
+        });
         if (!serialised || typeof serialised !== 'object') {
           return null;
         }


### PR DESCRIPTION
## Summary
- update the dashboard overlay serialisation helper to pass the new options object
- ensure scene saving uses the updated serialiseOverlayForScene configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d61b9960948321811eef6adec24057