### PR TITLE
Load client normalisers before dashboard script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1658,6 +1658,7 @@
 
   <script src="js/shared-config.js"></script>
   <script src="js/shared-utils.js"></script>
+  <script src="js/client-normalisers.js"></script>
 
   <script>
     const {


### PR DESCRIPTION
## Summary
- load the client-side normaliser bundle in index.html so window.TickerClientNormalisers is defined before the dashboard logic executes

## Testing
- HTTP_HOST=0.0.0.0 npm start

------
https://chatgpt.com/codex/tasks/task_e_68d61b9129a08321ae209cff897adaf5