### PR TITLE
Remove unused quantum theme and enforce allowed defaults

### DIFF
--- a/tests/state-roundtrip.test.js
+++ b/tests/state-roundtrip.test.js
@@ -8,6 +8,7 @@ const os = require('node:os');
 const { setTimeout: delay } = require('node:timers/promises');
 
 const ROOT_DIR = path.join(__dirname, '..');
+const { OVERLAY_THEMES } = require(path.join(ROOT_DIR, 'public/js/shared-config.js'));
 const HOST = '127.0.0.1';
 const TEST_PORT = 3202;
 const BASE_URL = `http://${HOST}:${TEST_PORT}`;
@@ -197,6 +198,10 @@ test('ticker state export/import round-trips through the API', async t => {
   const exportedState = await exportResponse.json();
   assert.ok(exportedState && typeof exportedState === 'object', 'export should return JSON');
   assert.equal(exportedState.overlay.label, overlayLabel, 'overlay label should retain 48 characters');
+  assert.ok(
+    OVERLAY_THEMES.includes(exportedState.overlay.theme),
+    'overlay theme should be one of the supported themes'
+  );
 
   // Mutate the state so the import has to overwrite everything
   await fetchJson(`${BASE_URL}/ticker/state`, {
@@ -255,6 +260,10 @@ test('ticker state export/import round-trips through the API', async t => {
 
   const overlayState = await fetchJson(`${BASE_URL}/ticker/overlay`);
   assert.deepEqual(overlayState, exportedState.overlay, 'overlay state should match exported payload');
+  assert.ok(
+    OVERLAY_THEMES.includes(overlayState.theme),
+    'persisted overlay theme should remain in the supported theme list'
+  );
 
   const slateState = await fetchJson(`${BASE_URL}/slate/state`);
   assert.deepEqual(slateState, exportedState.slate, 'slate state should match exported payload');

--- a/ticker-state.json
+++ b/ticker-state.json
@@ -28,7 +28,7 @@
     "mode": "auto",
     "accentAnim": true,
     "sparkle": true,
-    "theme": "quantum",
+    "theme": "midnight-glass",
     "_updatedAt": 1758648188427
   },
   "popup": {


### PR DESCRIPTION
## Summary
- align the seeded ticker state with supported overlay themes by swapping the orphaned "quantum" value for the default "midnight-glass"
- load the shared overlay theme list in the state round-trip test and assert both exported and reloaded themes remain within the allowed options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d626ab4130832182c00e733bfae66a