### PR TITLE
Normalize ticker server URL handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1765,6 +1765,7 @@
       normalisePosition: sharedNormalisePosition,
       normaliseTheme: sharedNormaliseTheme,
       normaliseSlateNotes,
+      normaliseServerBaseUrl: sharedNormaliseServerBaseUrl,
       isSafeCssColor: sharedIsSafeCssColor
     } = window.TickerShared || {};
 
@@ -1791,6 +1792,22 @@
       normaliseSceneEntry,
       sanitiseMessages
     } = normaliserExports;
+
+    const DEFAULT_SERVER_URL = 'http://127.0.0.1:3000';
+    const normaliseServerBase = typeof sharedNormaliseServerBaseUrl === 'function'
+      ? (value, fallback) => sharedNormaliseServerBaseUrl(value, fallback ?? DEFAULT_SERVER_URL)
+      : (value, fallback = DEFAULT_SERVER_URL) => {
+          const fallbackValue = typeof fallback === 'string' && fallback.trim()
+            ? fallback.trim()
+            : DEFAULT_SERVER_URL;
+          const raw = typeof value === 'string' ? value.trim() : '';
+          const target = raw || fallbackValue;
+          const cleaned = target
+            .replace(/(?:\/ticker)+\/?$/i, '')
+            .replace(/\/+$/g, '');
+          const fallbackClean = fallbackValue.replace(/\/+$/g, '');
+          return cleaned || fallbackClean;
+        };
 
     function normaliseThemeList(list) {
       if (!Array.isArray(list)) return [];
@@ -2275,8 +2292,7 @@
     }
 
     function serverBase() {
-      const value = (el.serverUrl.value || 'http://127.0.0.1:3000').trim();
-      return value.replace(/\/?$/, '');
+      return normaliseServerBase(el.serverUrl.value, DEFAULT_SERVER_URL);
     }
 
     function secondsToMinutes(seconds) {

--- a/public/output.html
+++ b/public/output.html
@@ -812,8 +812,25 @@
       clampScaleValue,
       clampPopupScaleValue,
       clampSlateRotationSeconds,
-      normaliseSlateNotes
+      normaliseSlateNotes,
+      normaliseServerBaseUrl: sharedNormaliseServerBaseUrl
     } = window.TickerShared || {};
+
+    const DEFAULT_SERVER_URL = 'http://127.0.0.1:3000';
+    const normaliseServerBase = typeof sharedNormaliseServerBaseUrl === 'function'
+      ? (value, fallback) => sharedNormaliseServerBaseUrl(value, fallback ?? DEFAULT_SERVER_URL)
+      : (value, fallback = DEFAULT_SERVER_URL) => {
+          const fallbackValue = typeof fallback === 'string' && fallback.trim()
+            ? fallback.trim()
+            : DEFAULT_SERVER_URL;
+          const raw = typeof value === 'string' ? value.trim() : '';
+          const target = raw || fallbackValue;
+          const cleaned = target
+            .replace(/(?:\/ticker)+\/?$/i, '')
+            .replace(/\/+$/g, '');
+          const fallbackClean = fallbackValue.replace(/\/+$/g, '');
+          return cleaned || fallbackClean;
+        };
 
     const SPECIAL_MAP = {
       '~~': 'rainbow',
@@ -2467,7 +2484,7 @@
     class TickerOverlay {
       constructor() {
         const params = new URLSearchParams(location.search);
-        this.server = (params.get('server') || 'http://127.0.0.1:3000').replace(/\/?$/, '');
+        this.server = normaliseServerBase(params.get('server'), DEFAULT_SERVER_URL);
         this.overlay = { ...DEFAULT_OVERLAY };
         this.overrides = {
           label: false,

--- a/tests/server-base-normalisation.test.js
+++ b/tests/server-base-normalisation.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { normaliseServerBaseUrl } = require('../public/js/shared-utils.js');
+
+const DEFAULT_INPUT = 'http://void.host:5678/ticker';
+
+function assertNoDuplicateTicker(urls) {
+  for (const url of urls) {
+    assert.ok(!/\/ticker\/ticker/i.test(url), `duplicate ticker segment in ${url}`);
+  }
+}
+
+test('dashboard and overlay normalise server base with trailing /ticker', () => {
+  const dashboardBase = normaliseServerBaseUrl(DEFAULT_INPUT);
+  const overlayBase = normaliseServerBaseUrl(DEFAULT_INPUT);
+
+  assert.equal(dashboardBase, 'http://void.host:5678');
+  assert.equal(overlayBase, 'http://void.host:5678');
+  assert.equal(normaliseServerBaseUrl(`${dashboardBase}/ticker`), 'http://void.host:5678');
+
+  assertNoDuplicateTicker([
+    `${dashboardBase}/ticker/state`,
+    `${dashboardBase}/ticker/overlay`,
+    `${dashboardBase}/ticker/presets`
+  ]);
+
+  assertNoDuplicateTicker([
+    `${overlayBase}/ticker/state`,
+    `${overlayBase}/ticker/overlay`,
+    `${overlayBase}/ticker/stream`
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a shared `normaliseServerBaseUrl` helper to strip trailing `/ticker` segments and slashes
- update the dashboard and overlay surfaces to reuse the helper when reading operator input
- add a regression test to ensure requests only include the `/ticker` prefix once

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d62cd6b1ec83218d0c51fe708e7b2e