### PR TITLE
Normalize server URL parsing for dashboard and overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1765,6 +1765,7 @@
       normalisePosition: sharedNormalisePosition,
       normaliseTheme: sharedNormaliseTheme,
       normaliseSlateNotes,
+      normaliseServerBase,
       isSafeCssColor: sharedIsSafeCssColor
     } = window.TickerShared || {};
 
@@ -2275,8 +2276,16 @@
     }
 
     function serverBase() {
-      const value = (el.serverUrl.value || 'http://127.0.0.1:3000').trim();
-      return value.replace(/\/?$/, '');
+      const fallback = (window.location && typeof window.location.origin === 'string')
+        ? window.location.origin
+        : 'http://127.0.0.1:3000';
+      if (typeof normaliseServerBase === 'function') {
+        return normaliseServerBase(el.serverUrl.value, fallback);
+      }
+      const value = (el.serverUrl.value || fallback).trim();
+      return value
+        .replace(/\/ticker\/?$/i, '')
+        .replace(/\/+$/, '');
     }
 
     function secondsToMinutes(seconds) {

--- a/public/output.html
+++ b/public/output.html
@@ -812,7 +812,8 @@
       clampScaleValue,
       clampPopupScaleValue,
       clampSlateRotationSeconds,
-      normaliseSlateNotes
+      normaliseSlateNotes,
+      normaliseServerBase
     } = window.TickerShared || {};
 
     const SPECIAL_MAP = {
@@ -2467,7 +2468,16 @@
     class TickerOverlay {
       constructor() {
         const params = new URLSearchParams(location.search);
-        this.server = (params.get('server') || 'http://127.0.0.1:3000').replace(/\/?$/, '');
+        const fallback = (window.location && typeof window.location.origin === 'string')
+          ? window.location.origin
+          : 'http://127.0.0.1:3000';
+        if (typeof normaliseServerBase === 'function') {
+          this.server = normaliseServerBase(params.get('server'), fallback);
+        } else {
+          this.server = (params.get('server') || fallback)
+            .replace(/\/ticker\/?$/i, '')
+            .replace(/\/+$/, '');
+        }
         this.overlay = { ...DEFAULT_OVERLAY };
         this.overrides = {
           label: false,

--- a/tests/client-normalisers.test.js
+++ b/tests/client-normalisers.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const normalisers = require('../public/js/client-normalisers.js');
+const { normaliseServerBase } = require('../public/js/shared-utils.js');
 
 const {
   normaliseOverlayData,
@@ -146,4 +147,12 @@ test('normaliseSceneEntry rejects empty payloads and preserves round-trip data',
   assert.ok(Number.isFinite(result.updatedAt));
 
   assert.deepStrictEqual(normaliseSceneEntry(result), result);
+});
+
+test('normaliseServerBase removes trailing ticker segment and slash', () => {
+  const fallback = 'https://fallback.example.com/ticker/';
+
+  assert.equal(normaliseServerBase('http://host/ticker/', fallback), 'http://host');
+  assert.equal(normaliseServerBase('https://host/', fallback), 'https://host');
+  assert.equal(normaliseServerBase('', fallback), 'https://fallback.example.com');
 });


### PR DESCRIPTION
## Summary
- add a shared normaliseServerBase helper that parses URLs and removes trailing /ticker segments
- update the dashboard and overlay pages to rely on the helper so requests use a sanitised base
- cover the helper with unit tests for common inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d62e778e508321bac369185377d212