### PR TITLE
Add linting and formatting tooling with CI coverage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,56 @@
+{
+  "root": true,
+  "env": {
+    "es2022": true,
+    "browser": true,
+    "node": true
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "script"
+  },
+  "plugins": [
+    "html",
+    "dom"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:dom/recommended",
+    "prettier"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "server.js",
+        "tests/**/*.js"
+      ],
+      "env": {
+        "browser": false,
+        "node": true
+      }
+    },
+    {
+      "files": [
+        "public/**/*.js"
+      ],
+      "env": {
+        "browser": true,
+        "node": false
+      },
+      "globals": {
+        "TickerShared": "readonly",
+        "SharedConfig": "readonly"
+      }
+    }
+  ],
+  "rules": {
+    "no-console": "off",
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run lint
+        run: npm run lint

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ This project exposes a lightweight dashboard and overlay for managing the ticker
 ## Getting Started
 
 1. Install dependencies: `npm install`
-2. Run the test suite: `npm test`
-3. Launch the server: `npm start`
+2. Run the linters: `npm run lint`
+3. Format the codebase: `npm run format`
+4. Run the test suite: `npm test`
+5. Launch the server: `npm start`
+
+The lint script covers both the Node.js backend and the browser modules under
+`public/`, while `npm run lint -- --fix` will attempt to auto-resolve any
+reporting issues. The `format` script applies the shared Prettier configuration;
+use `npm run format:check` to verify formatting without writing changes.
 
 With the server running on <http://127.0.0.1:3000>:
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,15 @@
+const { FlatCompat } = require('@eslint/eslintrc');
+const path = require('path');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname
+});
+
+const legacyConfig = require(path.join(__dirname, '.eslintrc.json'));
+
+module.exports = [
+  {
+    ignores: ['backup/**', 'node_modules/**']
+  },
+  ...compat.config(legacyConfig)
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,13 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2"
+      },
+      "devDependencies": {
+        "eslint": "^8.57.0",
+        "eslint-plugin-html": "^7.1.0",
+        "eslint-plugin-dom": "^3.1.0",
+        "eslint-config-prettier": "^9.1.0",
+        "prettier": "^3.2.5"
       }
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,21 @@
   "type": "commonjs",
   "scripts": {
     "start": "node server.js",
-    "test": "node --test"
+    "test": "node --test",
+    "lint": "eslint \"server.js\" \"tests/**/*.js\" \"public/**/*.js\"",
+    "lint:fix": "npm run lint -- --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-plugin-html": "^7.1.0",
+    "eslint-plugin-dom": "^3.1.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.5"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint and Prettier dev dependencies with npm scripts for linting and formatting
- document the new lint/format workflow in the README and add a flat-config shim for ESLint 9+
- configure a GitHub Actions workflow to run npm install, npm test, and npm run lint on pushes and pull requests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d62ea6d75c8321b7f42b496e4c8bd4