### PR TITLE
Normalise overlay server base from URL param

### DIFF
--- a/public/output.html
+++ b/public/output.html
@@ -2485,6 +2485,27 @@
       constructor() {
         const params = new URLSearchParams(location.search);
 
+        const fallbackOrigin =
+          typeof location === 'object' && location && typeof location.origin === 'string' && location.origin
+            ? location.origin
+            : DEFAULT_SERVER_URL;
+        const serverParam = params.get('server');
+        const normalisedServer = normaliseServerBase(serverParam, fallbackOrigin);
+        this.server = normalisedServer;
+
+        if (params.has('server') && typeof history === 'object' && history && typeof history.replaceState === 'function') {
+          const trimmedParam = typeof serverParam === 'string' ? serverParam.trim() : '';
+          if (trimmedParam !== normalisedServer) {
+            try {
+              const nextUrl = new URL(location.href);
+              nextUrl.searchParams.set('server', normalisedServer);
+              history.replaceState(null, '', nextUrl.toString());
+            } catch (error) {
+              console.warn('[ticker] failed to update server param', error);
+            }
+          }
+        }
+
         this.overlay = { ...DEFAULT_OVERLAY };
         this.overrides = {
           label: false,


### PR DESCRIPTION
## Summary
- normalise the ticker overlay server base from the query parameter with a fallback to the current origin
- persist the cleaned server base back to the URL so external embeds reuse the sanitised value

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d69d9cb2948321a6d453fe882f29c7