### PR TITLE
Handle undefined overlay server query parameters

### DIFF
--- a/public/output.html
+++ b/public/output.html
@@ -2490,12 +2490,23 @@
             ? location.origin
             : DEFAULT_SERVER_URL;
         const serverParam = params.get('server');
-        const normalisedServer = normaliseServerBase(serverParam, fallbackOrigin);
+        const trimmedServerParam = typeof serverParam === 'string' ? serverParam.trim() : '';
+        let sanitisedServerParam = trimmedServerParam;
+
+        if (sanitisedServerParam) {
+          const lowerValue = sanitisedServerParam.toLowerCase();
+          if (lowerValue === 'undefined' || lowerValue === 'null') {
+            sanitisedServerParam = '';
+          } else if (/\/undefined\/?$/i.test(lowerValue)) {
+            sanitisedServerParam = sanitisedServerParam.replace(/\/undefined\/?$/i, '');
+          }
+        }
+
+        const normalisedServer = normaliseServerBase(sanitisedServerParam, fallbackOrigin);
         this.server = normalisedServer;
 
         if (params.has('server') && typeof history === 'object' && history && typeof history.replaceState === 'function') {
-          const trimmedParam = typeof serverParam === 'string' ? serverParam.trim() : '';
-          if (trimmedParam !== normalisedServer) {
+          if (sanitisedServerParam !== normalisedServer) {
             try {
               const nextUrl = new URL(location.href);
               nextUrl.searchParams.set('server', normalisedServer);


### PR DESCRIPTION
## Summary
- sanitise the overlay server query parameter to treat `undefined`/`null` strings and trailing `/undefined` artefacts as invalid
- normalise the cleaned value and update the URL parameter so copied links always contain the usable origin

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a83f81008321a88abe6833e4824f