### PR TITLE
Improve request handling resilience and stream fallbacks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2084,6 +2084,77 @@
     const requestManager = typeof requestClientApi.create === 'function'
       ? requestClientApi.create({ defaultTimeoutMs: 8000 })
       : null;
+    const RequestErrorCtor = typeof requestClientApi.RequestError === 'function'
+      ? requestClientApi.RequestError
+      : class RequestError extends Error {
+          constructor(message, code, details = {}) {
+            super(message || 'Request failed');
+            this.name = 'RequestError';
+            this.code = code || 'request_error';
+            if (details && typeof details === 'object') {
+              Object.assign(this, details);
+            }
+          }
+        };
+
+    function createFallbackTimeoutController(timeoutMs, upstreamSignal) {
+      if (typeof AbortController !== 'function') {
+        return { signal: upstreamSignal, cleanup() {} };
+      }
+      const numericTimeout = Number(timeoutMs);
+      if (!Number.isFinite(numericTimeout) || numericTimeout <= 0) {
+        return { signal: upstreamSignal, cleanup() {} };
+      }
+
+      const controller = new AbortController();
+      let timeoutId = null;
+      let upstreamAbortListener = null;
+
+      if (upstreamSignal) {
+        if (upstreamSignal.aborted) {
+          controller.abort(upstreamSignal.reason);
+        } else {
+          upstreamAbortListener = () => controller.abort(upstreamSignal.reason);
+          upstreamSignal.addEventListener('abort', upstreamAbortListener, { once: true });
+        }
+      }
+
+      const timeoutError = new Error('Request timed out');
+      timeoutError.name = 'TimeoutError';
+      timeoutId = setTimeout(() => controller.abort(timeoutError), numericTimeout);
+
+      return {
+        signal: controller.signal,
+        cleanup() {
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+          }
+          if (upstreamAbortListener && upstreamSignal) {
+            upstreamSignal.removeEventListener('abort', upstreamAbortListener);
+            upstreamAbortListener = null;
+          }
+        }
+      };
+    }
+
+    async function performFallbackFetch(url, init = {}, timeoutMs) {
+      const controller = createFallbackTimeoutController(timeoutMs, init.signal);
+      const mergedInit = { ...init };
+      if (controller.signal) {
+        mergedInit.signal = controller.signal;
+      }
+      try {
+        const response = await fetch(url, mergedInit);
+        return { response, cleanup: controller.cleanup };
+      } catch (error) {
+        controller.cleanup();
+        if (error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
+          throw new RequestErrorCtor('Request timed out', 'timeout', { url });
+        }
+        throw new RequestErrorCtor(error?.message || 'Network request failed', 'network', { url, cause: error });
+      }
+    }
 
     function createAsyncQueue(options = {}) {
       if (requestManager && typeof requestManager.createQueue === 'function') {
@@ -2108,17 +2179,48 @@
         return requestManager.requestJson(url, options);
       }
       const init = options.init || {};
-      const response = await fetch(url, init);
+      const timeoutMs = options.timeoutMs;
+      const validate = options.validate;
+      const { response, cleanup } = await performFallbackFetch(url, init, timeoutMs);
+      let payload = null;
+      const contentType = (response.headers && response.headers.get && response.headers.get('content-type')) || '';
+      const expectsJson = /json/i.test(contentType || '');
+
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+        if (expectsJson) {
+          payload = await response.json().catch(() => null);
+        } else {
+          payload = await response.text().catch(() => null);
+        }
+        cleanup();
+        const message = typeof payload === 'object' && payload && typeof payload.error === 'string'
+          ? payload.error
+          : `Request failed with status ${response.status}`;
+        throw new RequestErrorCtor(message, 'http_error', { url, status: response.status, response: payload });
       }
-      const data = await response.json();
-      if (typeof options.validate === 'function') {
-        const result = options.validate(data);
+
+      let data;
+      try {
+        data = await response.json();
+      } catch (error) {
+        cleanup();
+        throw new RequestErrorCtor('Failed to parse response', 'parse_error', { url, cause: error });
+      }
+
+      cleanup();
+
+      if (typeof validate === 'function') {
+        const result = validate(data);
         if (result !== true && result !== undefined) {
-          throw new Error(typeof result === 'string' ? result : 'Invalid response');
+          const message = typeof result === 'string'
+            ? result
+            : (result && typeof result === 'object' && typeof result.message === 'string'
+              ? result.message
+              : 'Response validation failed');
+          throw new RequestErrorCtor(message, 'invalid_response', { url, response: data });
         }
       }
+
       return data;
     }
 
@@ -2127,11 +2229,29 @@
         return requestManager.request(url, { ...options, parser: 'blob' });
       }
       const init = options.init || {};
-      const response = await fetch(url, init);
+      const timeoutMs = options.timeoutMs;
+      const { response, cleanup } = await performFallbackFetch(url, init, timeoutMs);
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+        let payload = null;
+        try {
+          payload = await response.text();
+        } catch (err) {
+          payload = null;
+        }
+        cleanup();
+        const message = payload && typeof payload === 'string' && payload.trim()
+          ? payload.trim()
+          : `Request failed with status ${response.status}`;
+        throw new RequestErrorCtor(message, 'http_error', { url, status: response.status, response: payload });
       }
-      return response.blob();
+      try {
+        const blob = await response.blob();
+        cleanup();
+        return blob;
+      } catch (error) {
+        cleanup();
+        throw new RequestErrorCtor('Failed to parse blob response', 'parse_error', { url, cause: error });
+      }
     }
 
     function getLocalStorage() {
@@ -3365,6 +3485,7 @@
     let connectionRetryTimer = null;
     let connectionRetryAttempt = 0;
     let healthCheckTimer = null;
+    let consecutiveHealthFailures = 0;
     let pollingTimer = null;
     let currentServerStatus = 'checking';
     let isPollingActive = false;
@@ -3493,6 +3614,7 @@
 
     const HEALTH_CHECK_INTERVAL_MS = 30000;
     const HEALTH_CHECK_TIMEOUT_MS = 5000;
+    const HEALTH_CHECK_FAILURE_THRESHOLD = 2;
     const STREAM_BACKOFF_BASE_MS = 1000;
     const STREAM_BACKOFF_MAX_MS = 15000;
     const STREAM_MAX_FAILURES_BEFORE_POLLING = 3;
@@ -3689,6 +3811,7 @@
         clearInterval(healthCheckTimer);
         healthCheckTimer = null;
       }
+      consecutiveHealthFailures = 0;
     }
 
     function startHealthChecks() {
@@ -3696,13 +3819,31 @@
       healthCheckTimer = setInterval(async () => {
         const result = await checkServerHealth();
         if (!result.ok) {
+          consecutiveHealthFailures = Math.min(consecutiveHealthFailures + 1, 50);
           if (!isPollingActive) {
             const nextStatus = currentServerStatus === 'online' ? 'degraded' : 'offline';
             const message = resolveHealthMessage(result.reason, nextStatus);
             applyServerStatus(nextStatus, { message, force: true });
           }
-        } else if (!isPollingActive && currentServerStatus !== 'online') {
-          applyServerStatus('online', { force: true });
+          if (consecutiveHealthFailures >= HEALTH_CHECK_FAILURE_THRESHOLD) {
+            console.warn('[Ticker] Health checks failing, degrading stream connection', {
+              failures: consecutiveHealthFailures,
+              reason: result.reason
+            });
+            if (streamConnectionState === STREAM_STATES.OPEN || streamConnectionState === STREAM_STATES.CONNECTING) {
+              disconnectStream({ preservePolling: true });
+            }
+            if (!isPollingActive) {
+              startPolling('health-check');
+            }
+            scheduleReconnect('health-check');
+            void fetchState({ silent: true });
+          }
+        } else {
+          consecutiveHealthFailures = 0;
+          if (!isPollingActive && currentServerStatus !== 'online') {
+            applyServerStatus('online', { force: true });
+          }
         }
       }, HEALTH_CHECK_INTERVAL_MS);
     }

--- a/public/output.html
+++ b/public/output.html
@@ -949,6 +949,77 @@
     const requestManager = typeof requestClientApi.create === 'function'
       ? requestClientApi.create({ defaultTimeoutMs: 8000 })
       : null;
+    const RequestErrorCtor = typeof requestClientApi.RequestError === 'function'
+      ? requestClientApi.RequestError
+      : class RequestError extends Error {
+          constructor(message, code, details = {}) {
+            super(message || 'Request failed');
+            this.name = 'RequestError';
+            this.code = code || 'request_error';
+            if (details && typeof details === 'object') {
+              Object.assign(this, details);
+            }
+          }
+        };
+
+    function createFallbackTimeoutController(timeoutMs, upstreamSignal) {
+      if (typeof AbortController !== 'function') {
+        return { signal: upstreamSignal, cleanup() {} };
+      }
+      const numericTimeout = Number(timeoutMs);
+      if (!Number.isFinite(numericTimeout) || numericTimeout <= 0) {
+        return { signal: upstreamSignal, cleanup() {} };
+      }
+
+      const controller = new AbortController();
+      let timeoutId = null;
+      let upstreamAbortListener = null;
+
+      if (upstreamSignal) {
+        if (upstreamSignal.aborted) {
+          controller.abort(upstreamSignal.reason);
+        } else {
+          upstreamAbortListener = () => controller.abort(upstreamSignal.reason);
+          upstreamSignal.addEventListener('abort', upstreamAbortListener, { once: true });
+        }
+      }
+
+      const timeoutError = new Error('Request timed out');
+      timeoutError.name = 'TimeoutError';
+      timeoutId = setTimeout(() => controller.abort(timeoutError), numericTimeout);
+
+      return {
+        signal: controller.signal,
+        cleanup() {
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+          }
+          if (upstreamAbortListener && upstreamSignal) {
+            upstreamSignal.removeEventListener('abort', upstreamAbortListener);
+            upstreamAbortListener = null;
+          }
+        }
+      };
+    }
+
+    async function performFallbackFetch(url, init = {}, timeoutMs) {
+      const controller = createFallbackTimeoutController(timeoutMs, init.signal);
+      const mergedInit = { ...init };
+      if (controller.signal) {
+        mergedInit.signal = controller.signal;
+      }
+      try {
+        const response = await fetch(url, mergedInit);
+        return { response, cleanup: controller.cleanup };
+      } catch (error) {
+        controller.cleanup();
+        if (error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
+          throw new RequestErrorCtor('Request timed out', 'timeout', { url });
+        }
+        throw new RequestErrorCtor(error?.message || 'Network request failed', 'network', { url, cause: error });
+      }
+    }
 
     function createAsyncQueue(options = {}) {
       if (requestManager && typeof requestManager.createQueue === 'function') {
@@ -973,17 +1044,48 @@
         return requestManager.requestJson(url, options);
       }
       const init = options.init || {};
-      const response = await fetch(url, init);
+      const timeoutMs = options.timeoutMs;
+      const validate = options.validate;
+      const { response, cleanup } = await performFallbackFetch(url, init, timeoutMs);
+      let payload = null;
+      const contentType = (response.headers && response.headers.get && response.headers.get('content-type')) || '';
+      const expectsJson = /json/i.test(contentType || '');
+
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+        if (expectsJson) {
+          payload = await response.json().catch(() => null);
+        } else {
+          payload = await response.text().catch(() => null);
+        }
+        cleanup();
+        const message = typeof payload === 'object' && payload && typeof payload.error === 'string'
+          ? payload.error
+          : `Request failed with status ${response.status}`;
+        throw new RequestErrorCtor(message, 'http_error', { url, status: response.status, response: payload });
       }
-      const data = await response.json();
-      if (typeof options.validate === 'function') {
-        const result = options.validate(data);
+
+      let data;
+      try {
+        data = await response.json();
+      } catch (error) {
+        cleanup();
+        throw new RequestErrorCtor('Failed to parse response', 'parse_error', { url, cause: error });
+      }
+
+      cleanup();
+
+      if (typeof validate === 'function') {
+        const result = validate(data);
         if (result !== true && result !== undefined) {
-          throw new Error(typeof result === 'string' ? result : 'Invalid response');
+          const message = typeof result === 'string'
+            ? result
+            : (result && typeof result === 'object' && typeof result.message === 'string'
+              ? result.message
+              : 'Response validation failed');
+          throw new RequestErrorCtor(message, 'invalid_response', { url, response: data });
         }
       }
+
       return data;
     }
 
@@ -991,6 +1093,15 @@
       if (!queue) return task();
       return queue.enqueue(task);
     }
+
+    const STREAM_STATES = Object.freeze({
+      IDLE: 'idle',
+      CONNECTING: 'connecting',
+      OPEN: 'open',
+      ERROR: 'error',
+      POLLING: 'polling'
+    });
+    const STREAM_POLL_INTERVAL_MS = 8000;
 
     function isRecord(value) {
       return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -2776,12 +2887,15 @@
         this.chunkTimer = null;
         this.fetchInFlight = false;
         this.eventSource = null;
+        this.eventSourceListeners = [];
         this.streamFallbackTimer = null;
         this.streamReconnectTimer = null;
         this.streamPrimed = false;
         this.awaitingInitialStream = true;
         this.lastStreamFallbackAt = 0;
         this.streamRetryAttempt = 0;
+        this.streamState = STREAM_STATES.IDLE;
+        this.pollingTimer = null;
         this.stateRequestQueue = createAsyncQueue({ concurrency: 1 });
         this.rafId = null;
         this.distance = 0;
@@ -2827,6 +2941,7 @@
 
       dispose() {
         this.disconnectStream();
+        this.stopPolling();
         this.clearTimers();
         if (this.measureNode && this.measureNode.parentNode) {
           this.measureNode.parentNode.removeChild(this.measureNode);
@@ -3681,6 +3796,57 @@
         }
       }
 
+      setStreamState(nextState) {
+        if (!Object.values(STREAM_STATES).includes(nextState)) return;
+        if (this.streamState === nextState) return;
+        this.streamState = nextState;
+        if (nextState === STREAM_STATES.OPEN) {
+          this.streamRetryAttempt = 0;
+        }
+      }
+
+      detachEventSourceListeners(source = this.eventSource) {
+        if (!source || !Array.isArray(this.eventSourceListeners)) {
+          this.eventSourceListeners = [];
+          return;
+        }
+        for (const entry of this.eventSourceListeners) {
+          const { type, handler } = entry || {};
+          if (!type || typeof handler !== 'function') continue;
+          try {
+            source.removeEventListener(type, handler);
+          } catch (err) {
+            // ignore listener removal errors
+          }
+        }
+        this.eventSourceListeners = [];
+      }
+
+      startPolling(reason = 'stream-error') {
+        const alreadyPolling = Boolean(this.pollingTimer);
+        if (!alreadyPolling) {
+          const poll = () => {
+            if (!this.fetchInFlight) {
+              this.fetchState();
+            }
+          };
+          poll();
+          this.pollingTimer = setInterval(poll, STREAM_POLL_INTERVAL_MS);
+        }
+        this.setStreamState(STREAM_STATES.POLLING);
+        this.debugSet('Status', `polling (${reason})`);
+      }
+
+      stopPolling() {
+        if (this.pollingTimer) {
+          clearInterval(this.pollingTimer);
+          this.pollingTimer = null;
+        }
+        if (this.streamState === STREAM_STATES.POLLING) {
+          this.setStreamState(STREAM_STATES.IDLE);
+        }
+      }
+
       scheduleStreamFallback() {
         if (this.streamPrimed || !this.awaitingInitialStream) return;
         if (this.streamFallbackTimer) {
@@ -3721,7 +3887,15 @@
             ? 'initialising; fetching state'
             : 'stream error; fetching';
         this.debugSet('Status', status);
-        this.fetchState();
+        const shouldStartPolling = reason !== 'manual';
+        const wasPolling = Boolean(this.pollingTimer);
+        if (shouldStartPolling) {
+          const pollReason = reason === 'timeout' ? 'prime-timeout' : reason;
+          this.startPolling(pollReason);
+        }
+        if (!shouldStartPolling || wasPolling) {
+          this.fetchState();
+        }
       }
 
       scheduleStreamReconnect(reason = 'error') {
@@ -3733,12 +3907,20 @@
           this.streamReconnectTimer = null;
           this.connectStream();
         }, delay);
+        this.awaitingInitialStream = true;
+        this.setStreamState(STREAM_STATES.ERROR);
         this.debugSet('Status', `stream reconnecting (${reason})`);
       }
 
-      disconnectStream() {
+      disconnectStream(options = {}) {
+        const { preservePolling = false } = options;
         if (this.eventSource) {
-          this.eventSource.close();
+          this.detachEventSourceListeners(this.eventSource);
+          try {
+            this.eventSource.close();
+          } catch (err) {
+            // ignore close errors
+          }
           this.eventSource = null;
         }
         if (this.streamFallbackTimer) {
@@ -3750,29 +3932,48 @@
           this.streamReconnectTimer = null;
         }
         this.awaitingInitialStream = false;
+        if (!preservePolling) {
+          this.stopPolling();
+          this.setStreamState(STREAM_STATES.IDLE);
+        } else if (this.pollingTimer) {
+          this.setStreamState(STREAM_STATES.POLLING);
+        } else {
+          this.setStreamState(STREAM_STATES.IDLE);
+        }
       }
 
       connectStream() {
-        this.disconnectStream();
+        this.disconnectStream({ preservePolling: true });
         try {
           const source = new EventSource(`${this.server}/ticker/stream`);
           this.eventSource = source;
+          this.eventSourceListeners = [];
           this.streamPrimed = false;
           this.awaitingInitialStream = true;
+          this.setStreamState(STREAM_STATES.CONNECTING);
+          this.debugSet('Status', 'stream connecting');
           this.scheduleStreamFallback();
 
-          source.addEventListener('open', () => {
-            this.streamRetryAttempt = 0;
+          const register = (type, handler) => {
+            if (!type || typeof handler !== 'function') return;
+            source.addEventListener(type, handler);
+            this.eventSourceListeners.push({ type, handler });
+          };
+
+          register('open', () => {
             if (this.streamReconnectTimer) {
               clearTimeout(this.streamReconnectTimer);
               this.streamReconnectTimer = null;
             }
+            this.setStreamState(STREAM_STATES.OPEN);
             this.debugSet('Status', 'stream online');
+            this.stopPolling();
           });
 
-          source.addEventListener('error', () => {
+          register('error', () => {
             this.debugSet('Status', 'stream reconnecting');
             if (this.eventSource === source) {
+              this.detachEventSourceListeners(source);
               try {
                 source.close();
               } catch (err) {
@@ -3785,7 +3986,7 @@
             this.scheduleStreamReconnect('error');
           });
 
-          source.addEventListener('ticker', event => {
+          register('ticker', event => {
             try {
               const payload = JSON.parse(event.data);
               this.handleTickerPayload(payload);
@@ -3795,7 +3996,7 @@
             }
           });
 
-          source.addEventListener('overlay', event => {
+          register('overlay', event => {
             try {
               const payload = JSON.parse(event.data);
               this.applyOverlayData(payload);
@@ -3805,7 +4006,7 @@
             }
           });
 
-          source.addEventListener('popup', event => {
+          register('popup', event => {
             try {
               const payload = JSON.parse(event.data);
               this.handlePopupPayload(payload);
@@ -3815,7 +4016,7 @@
             }
           });
 
-          source.addEventListener('brb', event => {
+          register('brb', event => {
             try {
               const payload = JSON.parse(event.data);
               this.handleBrbPayload(payload);
@@ -3825,7 +4026,7 @@
             }
           });
 
-          source.addEventListener('slate', event => {
+          register('slate', event => {
             try {
               const payload = JSON.parse(event.data);
               this.handleSlatePayload(payload);
@@ -3839,6 +4040,7 @@
           this.debugSet('Status', 'stream error');
           this.streamPrimed = false;
           this.triggerStreamFallback('error');
+          this.startPolling('exception');
           this.scheduleStreamReconnect('exception');
         }
       }

--- a/tests/request-client.test.js
+++ b/tests/request-client.test.js
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { create, RequestError } = require('../public/js/request-client.js');
+
+function withMockedFetch(t, implementation) {
+  const originalFetch = global.fetch;
+  global.fetch = implementation;
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+}
+
+test('request client wraps network failures with RequestError metadata', async t => {
+  const client = create();
+  const networkError = new Error('network down');
+  withMockedFetch(t, async () => {
+    throw networkError;
+  });
+
+  await assert.rejects(
+    client.requestJson('https://example.com/data'),
+    err => {
+      assert(err instanceof RequestError);
+      assert.strictEqual(err.code, 'network');
+      assert.strictEqual(err.cause, networkError);
+      return true;
+    }
+  );
+});
+
+test('request client enforces timeouts via abort signals', async t => {
+  const client = create();
+  withMockedFetch(t, (url, init = {}) => new Promise((resolve, reject) => {
+    if (init && init.signal) {
+      init.signal.addEventListener('abort', () => {
+        const abortErr = new Error('Aborted');
+        abortErr.name = 'AbortError';
+        reject(abortErr);
+      });
+    }
+  }));
+
+  await assert.rejects(
+    client.requestJson('https://example.com/slow', { timeoutMs: 10 }),
+    err => {
+      assert(err instanceof RequestError);
+      assert.strictEqual(err.code, 'timeout');
+      return true;
+    }
+  );
+});
+
+test('queueKey serialises rapid successive calls', async t => {
+  const client = create();
+  let active = 0;
+  let maxConcurrent = 0;
+
+  withMockedFetch(t, async () => {
+    active += 1;
+    maxConcurrent = Math.max(maxConcurrent, active);
+    await new Promise(resolve => setTimeout(resolve, 5));
+    active -= 1;
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    });
+  });
+
+  await Promise.all([
+    client.requestJson('https://example.com/a', { queueKey: 'serial' }),
+    client.requestJson('https://example.com/b', { queueKey: 'serial' }),
+    client.requestJson('https://example.com/c', { queueKey: 'serial' })
+  ]);
+
+  assert.strictEqual(active, 0);
+  assert.strictEqual(maxConcurrent, 1);
+});
+
+test('response validation failures raise invalid_response errors', async t => {
+  const client = create();
+  withMockedFetch(t, async () => new Response(JSON.stringify({ ok: false }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  }));
+
+  await assert.rejects(
+    client.requestJson('https://example.com/data', {
+      validate: payload => (payload.ok ? true : 'Payload missing ok flag')
+    }),
+    err => {
+      assert(err instanceof RequestError);
+      assert.strictEqual(err.code, 'invalid_response');
+      assert.strictEqual(err.message, 'Payload missing ok flag');
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a RequestClient-backed fallback in the dashboard and output apps so timeouts, errors, and validation are consistent even without the helper
- harden dashboard stream recovery by tracking consecutive health check failures, degrading to polling, and kicking off reconnects with backoff
- refactor the output overlay to manage EventSource listeners, expose polling fallback, and surface new request-client tests covering timeouts, queueing, and validation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d967935b388321a6fd1d7d91256ea9