### PR TITLE
Use shared server normaliser in overlay

### DIFF
--- a/public/output.html
+++ b/public/output.html
@@ -809,6 +809,8 @@
       normaliseMode: sharedNormaliseMode,
       normalisePosition: sharedNormalisePosition,
       normaliseTheme: sharedNormaliseTheme,
+      normaliseServerBase: sharedNormaliseServerBase,
+      normaliseServerBaseUrl: sharedNormaliseServerBaseUrl,
       isSafeCssColor,
       clampScaleValue,
       clampPopupScaleValue,
@@ -818,20 +820,23 @@
     } = window.TickerShared || {};
 
     const DEFAULT_SERVER_URL = 'http://127.0.0.1:3000';
-    const normaliseServerBase = typeof sharedNormaliseServerBaseUrl === 'function'
-      ? (value, fallback) => sharedNormaliseServerBaseUrl(value, fallback ?? DEFAULT_SERVER_URL)
-      : (value, fallback = DEFAULT_SERVER_URL) => {
-          const fallbackValue = typeof fallback === 'string' && fallback.trim()
-            ? fallback.trim()
-            : DEFAULT_SERVER_URL;
-          const raw = typeof value === 'string' ? value.trim() : '';
-          const target = raw || fallbackValue;
-          const cleaned = target
-            .replace(/(?:\/ticker)+\/?$/i, '')
-            .replace(/\/+$/g, '');
-          const fallbackClean = fallbackValue.replace(/\/+$/g, '');
-          return cleaned || fallbackClean;
-        };
+    const manualNormaliseServerBase = (value, fallback = DEFAULT_SERVER_URL) => {
+      const fallbackValue = typeof fallback === 'string' && fallback.trim()
+        ? fallback.trim()
+        : DEFAULT_SERVER_URL;
+      const raw = typeof value === 'string' ? value.trim() : '';
+      const target = raw || fallbackValue;
+      const cleaned = target
+        .replace(/(?:\/ticker)+\/?$/i, '')
+        .replace(/\/+$/g, '');
+      const fallbackClean = fallbackValue.replace(/\/+$/g, '');
+      return cleaned || fallbackClean;
+    };
+    const normaliseServerBase = typeof sharedNormaliseServerBase === 'function'
+      ? (value, fallback) => sharedNormaliseServerBase(value, fallback ?? DEFAULT_SERVER_URL)
+      : typeof sharedNormaliseServerBaseUrl === 'function'
+        ? (value, fallback) => sharedNormaliseServerBaseUrl(value, fallback ?? DEFAULT_SERVER_URL)
+        : manualNormaliseServerBase;
 
     const SPECIAL_MAP = {
       '~~': 'rainbow',


### PR DESCRIPTION
## Summary
- destructure the shared server normalisation helpers in the overlay output script
- delegate server URL normalisation to the shared helpers, only falling back to the local implementation when needed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d96e71ef5c8321a3dc354d3af44446