### PR TITLE
Guard dashboard fallback against invalid origins

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4090,8 +4090,18 @@
         : '';
 
       const fallbackOrigin = (() => {
-        if (typeof location === 'object' && location && typeof location.origin === 'string' && location.origin) {
-          return location.origin;
+        if (typeof location === 'object' && location && typeof location.origin === 'string') {
+          const origin = location.origin.trim();
+          if (origin && origin !== 'null') {
+            try {
+              const parsed = new URL(origin);
+              if (/^https?:$/.test(parsed.protocol)) {
+                return parsed.origin;
+              }
+            } catch (error) {
+              console.warn('[Ticker] Ignoring invalid location.origin', { origin, error });
+            }
+          }
         }
         return DEFAULT_SERVER_URL;
       })();


### PR DESCRIPTION
## Summary
- ensure the dashboard ignores invalid `location.origin` values when picking a fallback server URL
- add logging to surface when the origin is discarded and the default URL is used

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d971b6814883218f8b2f486446e30b