### PR TITLE
Fix server startup logging and env var defaults

### DIFF
--- a/server.js
+++ b/server.js
@@ -937,10 +937,17 @@ if (assetDir === DEFAULT_ASSET_DIR) {
 
 async function start() {
   await loadStateFromDisk();
-  const host = process.env.HTTP_HOST || '0.0.0.0';
-  const port = Number(process.env.HTTP_PORT) || 3000;
+  const host =
+    process.env.HTTP_HOST ||
+    process.env.HOST ||
+    (process.platform === 'win32' ? '127.0.0.1' : '0.0.0.0');
+  const port = Number(process.env.HTTP_PORT || process.env.PORT) || 3000;
   const server = app.listen(port, host, () => {
-    console.log(`listening on http://${host}:${port}`);
+    const baseUrl = `http://${host}:${port}`;
+    console.log(`[ticker] listening on ${baseUrl}`);
+    console.log(`[ticker] dashboard available at ${baseUrl}/ticker/index.html`);
+    console.log(`[ticker] overlay available at ${baseUrl}/ticker/output.html`);
+    console.log(`[ticker] SSE stream available at ${baseUrl}/ticker/stream`);
   });
   const shutdown = () => {
     server.close(() => {


### PR DESCRIPTION
## Summary
- fall back to HOST/PORT environment variables and a platform-specific default host when starting the server
- restore verbose startup logging that calls out the dashboard, overlay, and SSE URLs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9792991c483219a0e81403e91e704