### PR TITLE
Improve SSE resilience and state mutation concurrency

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6028,11 +6028,13 @@
 
     async function persistState() {
       const base = serverBase();
+      const timestamp = Number(state.updatedAt ?? state._updatedAt);
       const payload = {
         isActive: state.isActive,
         messages: state.messages,
         displayDuration: state.displayDuration,
-        intervalBetween: minutesToSeconds(state.intervalMinutes)
+        intervalBetween: minutesToSeconds(state.intervalMinutes),
+        updatedAt: Number.isFinite(timestamp) ? timestamp : null
       };
       try {
         await runQueued(mutationQueues.ticker, async () => {
@@ -6051,9 +6053,20 @@
             applyServerStatus('online');
           } catch (err) {
             console.error('Failed to save state', err);
-            toast(err.message || 'Failed to save ticker state');
-            applyServerStatus('error', { force: true });
-            markErrorHandled(err);
+            if (err && err.status === 409) {
+              markErrorHandled(err);
+              const latest = err.response && err.response.state;
+              if (latest) {
+                applyTickerData(latest);
+              } else {
+                void fetchState({ silent: true });
+              }
+              toast('Ticker updated on another device. Latest version loaded.');
+            } else {
+              toast(err && err.message ? err.message : 'Failed to save ticker state');
+              applyServerStatus('error', { force: true });
+              markErrorHandled(err);
+            }
             throw err;
           }
         });
@@ -6365,6 +6378,41 @@
       }
     }
 
+    function handleStreamPayloadError(kind, error) {
+      console.warn(`[Ticker] Failed to process ${kind} stream payload`, error);
+      if (!isPollingActive) {
+        startPolling(`${kind}-parse`);
+      } else {
+        setStreamState(STREAM_STATES.POLLING, { reason: `${kind}-parse` });
+      }
+      applyServerStatus('reconnecting', { force: true });
+      disconnectStream({ preservePolling: true });
+      void fetchState({ silent: true });
+      scheduleReconnect(`${kind}-parse`);
+    }
+
+    function processStreamPayload(kind, event, handler) {
+      if (!event || typeof event.data !== 'string') {
+        handleStreamPayloadError(kind, new Error('Missing event payload'));
+        return;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(event.data);
+      } catch (error) {
+        handleStreamPayloadError(kind, error);
+        return;
+      }
+      try {
+        const applied = handler(parsed);
+        if (applied !== false) {
+          markStreamPrimed();
+        }
+      } catch (error) {
+        handleStreamPayloadError(kind, error);
+      }
+    }
+
     function detachEventSourceListeners(source = eventSource) {
       if (!source || !Array.isArray(eventSourceListeners)) {
         eventSourceListeners = [];
@@ -6536,77 +6584,53 @@
         });
 
         register('ticker', event => {
-          try {
-            const data = JSON.parse(event.data);
+          processStreamPayload('ticker', event, data => {
             applyTickerData(data);
-            markStreamPrimed();
-          } catch (err) {
-            console.warn('Failed to parse ticker stream payload', err);
-          }
+          });
         });
 
         register('overlay', event => {
-          try {
-            const data = JSON.parse(event.data);
+          processStreamPayload('overlay', event, data => {
             applyOverlayData(data);
-            markStreamPrimed();
-          } catch (err) {
-            console.warn('Failed to parse overlay stream payload', err);
-          }
+          });
         });
 
         register('presets', event => {
-          try {
-            const data = JSON.parse(event.data);
+          processStreamPayload('presets', event, data => {
             if (Array.isArray(data)) {
               applyPresetsData(data);
+              return true;
             }
-            markStreamPrimed();
-          } catch (err) {
-            console.warn('Failed to parse presets stream payload', err);
-          }
+            return false;
+          });
         });
 
         register('scenes', event => {
-          try {
-            const data = JSON.parse(event.data);
+          processStreamPayload('scenes', event, data => {
             if (Array.isArray(data)) {
               applyScenesData(data);
+              return true;
             }
-            markStreamPrimed();
-          } catch (err) {
-            console.warn('Failed to parse scenes stream payload', err);
-          }
+            return false;
+          });
         });
 
         register('popup', event => {
-          try {
-            const data = JSON.parse(event.data);
+          processStreamPayload('popup', event, data => {
             applyPopupData(data);
-            markStreamPrimed();
-          } catch (err) {
-            console.warn('Failed to parse popup stream payload', err);
-          }
+          });
         });
 
         register('slate', event => {
-          try {
-            const data = JSON.parse(event.data);
+          processStreamPayload('slate', event, data => {
             applySlateData(data);
-            markStreamPrimed();
-          } catch (err) {
-            console.warn('Failed to parse slate stream payload', err);
-          }
+          });
         });
 
         register('brb', event => {
-          try {
-            const data = JSON.parse(event.data);
+          processStreamPayload('brb', event, data => {
             applyBrbData(data);
-            markStreamPrimed();
-          } catch (err) {
-            console.warn('Failed to parse BRB stream payload', err);
-          }
+          });
         });
       } catch (err) {
         console.error('Failed to connect to event stream', err);

--- a/public/output.html
+++ b/public/output.html
@@ -2639,10 +2639,25 @@
         return this._factories;
       }
 
+      instantiateEngine(themeKey, colors = {}) {
+        const factories = ThemeVisualController.factories;
+        const factory = factories[themeKey];
+        if (typeof factory !== 'function') {
+          return null;
+        }
+        try {
+          return factory(this.container, { ...colors, reducedMotion: this.reducedMotion });
+        } catch (error) {
+          console.warn(`[ticker] failed to initialise ${themeKey} visuals`, error);
+          return null;
+        }
+      }
+
       setTheme(theme, colors = {}) {
         if (!this.container) return;
         const factories = ThemeVisualController.factories;
-        const resolvedTheme = (theme && factories[theme]) ? theme : 'midnight-glass';
+        const fallbackTheme = 'duotone-fusion';
+        const resolvedTheme = theme && factories[theme] ? theme : 'midnight-glass';
         if (this.current && this.current.name === resolvedTheme) {
           if (typeof this.current.updateColors === 'function') {
             this.current.updateColors(colors);
@@ -2655,8 +2670,14 @@
         if (this.container) {
           this.container.innerHTML = '';
         }
-        const factory = factories[resolvedTheme];
-        this.current = factory ? factory(this.container, { ...colors, reducedMotion: this.reducedMotion }) : null;
+        let instance = this.instantiateEngine(resolvedTheme, colors);
+        if (!instance && resolvedTheme !== fallbackTheme) {
+          instance = this.instantiateEngine(fallbackTheme, colors);
+        }
+        this.current = instance || null;
+        if (this.current && typeof this.current.updateColors === 'function') {
+          this.current.updateColors(colors);
+        }
       }
 
       updateColors(colors = {}) {
@@ -3901,15 +3922,16 @@
         }
       }
 
-      triggerStreamFallback(reason) {
-        if (this.streamPrimed || !this.awaitingInitialStream) return;
+      triggerStreamFallback(reason, options = {}) {
+        const { force = false } = options;
+        if (!force && (this.streamPrimed || !this.awaitingInitialStream)) return;
         if (this.streamFallbackTimer) {
           clearTimeout(this.streamFallbackTimer);
           this.streamFallbackTimer = null;
         }
-        if (this.fetchInFlight) return;
+        if (!force && this.fetchInFlight) return;
         const now = Date.now();
-        if (this.lastStreamFallbackAt && now - this.lastStreamFallbackAt < 1000) {
+        if (!force && this.lastStreamFallbackAt && now - this.lastStreamFallbackAt < 1000) {
           return;
         }
         this.lastStreamFallbackAt = now;
@@ -3926,8 +3948,39 @@
           const pollReason = reason === 'timeout' ? 'prime-timeout' : reason;
           this.startPolling(pollReason);
         }
-        if (!shouldStartPolling || wasPolling) {
-          this.fetchState();
+        this.fetchState();
+      }
+
+      handleStreamPayloadError(kind, error) {
+        console.warn(`[ticker] stream ${kind} payload error`, error);
+        if (!this.pollingTimer) {
+          this.startPolling(`${kind}-parse`);
+        }
+        this.disconnectStream({ preservePolling: true });
+        this.triggerStreamFallback('parse-error', { force: true });
+        this.scheduleStreamReconnect('parse-error');
+        this.fetchState();
+      }
+
+      processStreamPayload(kind, event, handler) {
+        if (!event || typeof event.data !== 'string') {
+          this.handleStreamPayloadError(kind, new Error('Missing event payload'));
+          return;
+        }
+        let parsed;
+        try {
+          parsed = JSON.parse(event.data);
+        } catch (err) {
+          this.handleStreamPayloadError(kind, err);
+          return;
+        }
+        try {
+          const applied = handler(parsed);
+          if (applied !== false) {
+            this.markStreamPrimed();
+          }
+        } catch (err) {
+          this.handleStreamPayloadError(kind, err);
         }
       }
 
@@ -4015,58 +4068,38 @@
               this.eventSource = null;
             }
             this.scheduleStreamFallback();
-            this.triggerStreamFallback('error');
+            this.triggerStreamFallback('error', { force: true });
             this.scheduleStreamReconnect('error');
           });
 
           register('ticker', event => {
-            try {
-              const payload = JSON.parse(event.data);
+            this.processStreamPayload('ticker', event, payload => {
               this.handleTickerPayload(payload);
-              this.markStreamPrimed();
-            } catch (err) {
-              console.warn('[ticker] stream ticker parse failed', err);
-            }
+            });
           });
 
           register('overlay', event => {
-            try {
-              const payload = JSON.parse(event.data);
+            this.processStreamPayload('overlay', event, payload => {
               this.applyOverlayData(payload);
-              this.markStreamPrimed();
-            } catch (err) {
-              console.warn('[ticker] stream overlay parse failed', err);
-            }
+            });
           });
 
           register('popup', event => {
-            try {
-              const payload = JSON.parse(event.data);
+            this.processStreamPayload('popup', event, payload => {
               this.handlePopupPayload(payload);
-              this.markStreamPrimed();
-            } catch (err) {
-              console.warn('[ticker] stream popup parse failed', err);
-            }
+            });
           });
 
           register('brb', event => {
-            try {
-              const payload = JSON.parse(event.data);
+            this.processStreamPayload('brb', event, payload => {
               this.handleBrbPayload(payload);
-              this.markStreamPrimed();
-            } catch (err) {
-              console.warn('[ticker] stream brb parse failed', err);
-            }
+            });
           });
 
           register('slate', event => {
-            try {
-              const payload = JSON.parse(event.data);
+            this.processStreamPayload('slate', event, payload => {
               this.handleSlatePayload(payload);
-              this.markStreamPrimed();
-            } catch (err) {
-              console.warn('[ticker] stream slate parse failed', err);
-            }
+            });
           });
         } catch (err) {
           console.error('[ticker] failed to connect to stream', err);


### PR DESCRIPTION
## Summary
- serialize server-side state writes, validate update timestamps, and surface 409 conflicts when stale payloads arrive
- add dashboard and overlay EventSource fallbacks with better polling recovery and ensure the overlay animation engine boots cleanly
- extend integration coverage for rejecting stale updates and recovering with the latest server state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d98b870c9083218bb85f1e18834db8