### PR TITLE
Tidy example assets under public/

### DIFF
--- a/public/examples/bingo.html
+++ b/public/examples/bingo.html
@@ -9,8 +9,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
 
-  <!-- Your style tokens / motion presets (place this file next to bingo.html) -->
-  <link rel="stylesheet" href="themes.css">
+  <!-- Your style tokens / motion presets -->
+  <link rel="stylesheet" href="../css/themes.css">
 
   <!-- Anime.js for tiny, silky animations -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.2/anime.min.js" defer></script>


### PR DESCRIPTION
## Summary
- move the example bingo page from `public/css/` into a dedicated `public/examples/` folder
- update the example page to reference the shared theme stylesheet from its new relative path
- drop the stray placeholder file from `public/css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68d98ab376808321a1ec55f5961ac7b0