### PR TITLE
Enhance message sanitisation and metadata handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2763,25 +2763,61 @@
           const {
             maxMessages = FALLBACK_MAX_MESSAGES,
             maxLength = FALLBACK_MAX_MESSAGE_LENGTH,
+            maxMetaLength = FALLBACK_MAX_MESSAGE_LENGTH,
             includeMeta = false,
             strict = false
           } = options;
+
+          const maxMessageLimit = Number.isFinite(Number(maxMessages))
+            ? Math.max(0, Math.round(Number(maxMessages)))
+            : FALLBACK_MAX_MESSAGES;
+          const maxLengthLimit = Number.isFinite(Number(maxLength))
+            ? Math.max(1, Math.round(Number(maxLength)))
+            : FALLBACK_MAX_MESSAGE_LENGTH;
+          const maxMetaLimit = Number.isFinite(Number(maxMetaLength))
+            ? Math.max(0, Math.round(Number(maxMetaLength)))
+            : FALLBACK_MAX_MESSAGE_LENGTH;
+
           const cleaned = [];
+          const metadata = [];
           let trimmed = 0;
           let truncated = 0;
+
           for (const entry of list) {
             let text = '';
+            let metaValue = null;
+
             if (typeof entry === 'string') {
               text = entry.trim();
-            } else if (entry && typeof entry === 'object' && typeof entry.text === 'string') {
-              text = entry.text.trim();
+            } else if (entry && typeof entry === 'object') {
+              if (typeof entry.text === 'string') {
+                text = entry.text.trim();
+              } else if (typeof entry.message === 'string') {
+                text = entry.message.trim();
+              } else if (typeof entry.value === 'string') {
+                text = entry.value.trim();
+              } else if (typeof entry.toString === 'function' && entry.toString !== Object.prototype.toString) {
+                text = String(entry).trim();
+              }
+
+              if (includeMeta) {
+                const rawMeta = entry.meta != null ? entry.meta : entry.description;
+                if (typeof rawMeta === 'string') {
+                  const trimmedMeta = rawMeta.trim();
+                  if (trimmedMeta) {
+                    metaValue = trimmedMeta.slice(0, maxMetaLimit);
+                  }
+                }
+              }
             } else {
               text = String(entry == null ? '' : entry).trim();
             }
+
             if (!text) continue;
-            if (cleaned.length >= maxMessages) {
+
+            if (cleaned.length >= maxMessageLimit) {
               if (strict) {
-                throw new Error(`Too many ticker messages (maximum ${maxMessages}).`);
+                throw new Error(`Too many ticker messages (maximum ${maxMessageLimit}).`);
               }
               truncated += 1;
               if (!includeMeta) {
@@ -2789,17 +2825,23 @@
               }
               continue;
             }
-            if (text.length > maxLength) {
+
+            if (text.length > maxLengthLimit) {
               if (strict) {
-                throw new Error(`Ticker messages must be ${maxLength} characters or fewer.`);
+                throw new Error(`Ticker messages must be ${maxLengthLimit} characters or fewer.`);
               }
-              text = text.slice(0, maxLength);
+              text = text.slice(0, maxLengthLimit);
               trimmed += 1;
             }
+
             cleaned.push(text);
+            if (includeMeta) {
+              metadata.push(metaValue);
+            }
           }
+
           if (includeMeta) {
-            return { messages: cleaned, trimmed, truncated };
+            return { messages: cleaned, meta: metadata, trimmed, truncated };
           }
           return cleaned;
         };

--- a/public/output.html
+++ b/public/output.html
@@ -1425,17 +1425,91 @@
       };
     }
 
-    function sanitiseMessages(list) {
-      if (!Array.isArray(list)) return [];
+    function sanitiseMessages(list, options = {}) {
+      const includeMeta = !!options.includeMeta;
+      if (!Array.isArray(list)) {
+        return includeMeta ? { messages: [], meta: [], trimmed: 0, truncated: 0 } : [];
+      }
+
+      const {
+        maxMessages = MAX_MESSAGES,
+        maxLength = MAX_MESSAGE_LENGTH,
+        maxMetaLength = 200,
+        strict = false
+      } = options;
+
+      const maxMessageLimit = Number.isFinite(Number(maxMessages))
+        ? Math.max(0, Math.round(Number(maxMessages)))
+        : MAX_MESSAGES;
+      const maxLengthLimit = Number.isFinite(Number(maxLength))
+        ? Math.max(1, Math.round(Number(maxLength)))
+        : MAX_MESSAGE_LENGTH;
+      const maxMetaLimit = Number.isFinite(Number(maxMetaLength))
+        ? Math.max(0, Math.round(Number(maxMetaLength)))
+        : 200;
+
       const cleaned = [];
+      const metadata = [];
+      let trimmed = 0;
+      let truncated = 0;
+
       for (const entry of list) {
-        if (cleaned.length >= MAX_MESSAGES) break;
-        let text = String(entry == null ? '' : entry).trim();
-        if (!text) continue;
-        if (text.length > MAX_MESSAGE_LENGTH) {
-          text = text.slice(0, MAX_MESSAGE_LENGTH);
+        let text = '';
+        let metaValue = null;
+
+        if (typeof entry === 'string') {
+          text = entry.trim();
+        } else if (entry && typeof entry === 'object') {
+          if (typeof entry.text === 'string') {
+            text = entry.text.trim();
+          } else if (typeof entry.message === 'string') {
+            text = entry.message.trim();
+          } else if (typeof entry.value === 'string') {
+            text = entry.value.trim();
+          } else if (typeof entry.toString === 'function' && entry.toString !== Object.prototype.toString) {
+            text = String(entry).trim();
+          }
+
+          if (includeMeta) {
+            const rawMeta = entry.meta != null ? entry.meta : entry.description;
+            if (typeof rawMeta === 'string') {
+              const trimmedMeta = rawMeta.trim();
+              if (trimmedMeta) {
+                metaValue = trimmedMeta.slice(0, maxMetaLimit);
+              }
+            }
+          }
+        } else {
+          text = String(entry == null ? '' : entry).trim();
         }
+
+        if (!text) continue;
+
+        if (cleaned.length >= maxMessageLimit) {
+          if (strict) {
+            throw new Error(`Too many ticker messages (maximum ${maxMessageLimit}).`);
+          }
+          truncated += 1;
+          if (!includeMeta) break;
+          continue;
+        }
+
+        if (text.length > maxLengthLimit) {
+          if (strict) {
+            throw new Error(`Ticker messages must be ${maxLengthLimit} characters or fewer.`);
+          }
+          text = text.slice(0, maxLengthLimit);
+          trimmed += 1;
+        }
+
         cleaned.push(text);
+        if (includeMeta) {
+          metadata.push(metaValue);
+        }
+      }
+
+      if (includeMeta) {
+        return { messages: cleaned, meta: metadata, trimmed, truncated };
       }
       return cleaned;
     }

--- a/tests/client-normalisers.test.js
+++ b/tests/client-normalisers.test.js
@@ -120,7 +120,12 @@ test('normaliseSceneEntry rejects empty payloads and preserves round-trip data',
   const entry = {
     id: 'scene-custom',
     name: '  Showcase  ',
-    messages: ['  Hello  ', '', 'World', 'A'.repeat(400)],
+    messages: [
+      '  Hello  ',
+      { text: '', meta: 'ignore' },
+      { text: 'World', meta: 'world meta' },
+      { text: 'A'.repeat(400), meta: 'trimmed meta' }
+    ],
     displayDuration: 1,
     intervalBetween: 7200,
     isActive: true,

--- a/tests/shared-utils.test.js
+++ b/tests/shared-utils.test.js
@@ -61,10 +61,25 @@ test('normaliseHighlightList trims whitespace and drops empty entries', () => {
 
 test('sanitiseMessages enforces limits, supports metadata, and strict errors', () => {
   const overlong = 'A'.repeat(MAX_TICKER_MESSAGE_LENGTH + 10);
-  const input = ['  Hello  ', '', overlong, 'Third', 'Fourth'];
+  const input = [
+    '  Hello  ',
+    { text: overlong, meta: '  First meta entry that will be trimmed  ' },
+    { message: 'Third', meta: 'Third meta detail' },
+    { value: 'Fourth', description: 'Fourth meta' },
+    'Fifth'
+  ];
 
-  const metaResult = sanitiseMessages(input, { includeMeta: true, maxMessages: 2 });
-  assert.deepStrictEqual(metaResult.messages, ['Hello', 'A'.repeat(MAX_TICKER_MESSAGE_LENGTH)]);
+  const metaResult = sanitiseMessages(input, {
+    includeMeta: true,
+    maxMessages: 3,
+    maxMetaLength: 10
+  });
+
+  assert.deepStrictEqual(
+    metaResult.messages,
+    ['Hello', 'A'.repeat(MAX_TICKER_MESSAGE_LENGTH), 'Third']
+  );
+  assert.deepStrictEqual(metaResult.meta, [null, 'First meta', 'Third meta']);
   assert.equal(metaResult.trimmed, 1);
   assert.equal(metaResult.truncated, 2);
 


### PR DESCRIPTION
## Summary
- extend `sanitiseMessages` to support structured entries, metadata trimming, and numeric bounds shared with client normalisers
- update dashboard and output fallbacks so degraded-mode sanitisation matches the shared helper
- exercise the new behaviour with additional shared-utils and scene normaliser tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d99853e37c8321aaeafa3b78fbfe66