### PR TITLE
Add debug logging for message form detection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8919,14 +8919,18 @@
       }
 
       if (el.messageForm && el.newMessage) {
+        console.log('[DEBUG] Message form found, adding listener');
         el.messageForm.addEventListener('submit', event => {
           event.preventDefault();
+          console.log('[DEBUG] Form submitted, adding message:', el.newMessage.value);
           const added = addMessage(el.newMessage.value);
           if (added) {
             el.newMessage.value = '';
           }
           el.newMessage.focus();
         });
+      } else {
+        console.error('[DEBUG] Message form or input not found:', { form: !!el.messageForm, input: !!el.newMessage });
       }
 
       if (el.clearMessages) {


### PR DESCRIPTION
## Summary
- add debug logging when the message form is located
- log submission details and missing element information to aid debugging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9997527b08321add8ec69e3429943