### PR TITLE
Add critical element validation before registering handlers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8150,7 +8150,15 @@
 
       const on = addManagedEventListener;
 
-      // Defensive: log missing elements
+      // Defensive: log missing elements and bail early for critical ones
+      const criticalElements = ['messageForm', 'newMessage', 'serverUrl'];
+      for (const key of criticalElements) {
+        if (!el[key]) {
+          console.error(`[Ticker] Critical element missing: ${key}`);
+          return;
+        }
+      }
+
       for (const [key, value] of Object.entries(el)) {
         if (!value) {
           console.warn(`[Ticker] Missing DOM element: el.${key}`);


### PR DESCRIPTION
## Summary
- ensure registerEventHandlers checks for critical DOM elements before wiring events
- log an error and abort handler registration when key elements are missing
- retain existing warnings for other missing elements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d999910e6c832189a28172281cb6e5