### PR TITLE
Add debug logging for stream connection flow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7054,16 +7054,20 @@
     async function connectStream(options = {}) {
       try {
         const { isRetry = false, reason = 'manual' } = options;
-      disconnectStream({ preservePolling: true });
-      if (!isRetry) {
-        connectionRetryAttempt = 0;
-      }
-      const validation = getValidatedServerBase();
-      if (!validation.ok || !validation.url) {
-        applyServerStatus('invalid', { force: true });
-        stopPolling();
-        return;
-      }
+        console.log('[DEBUG] Connecting stream:', { isRetry, reason, server: serverBase() });
+        disconnectStream({ preservePolling: true });
+        if (!isRetry) {
+          connectionRetryAttempt = 0;
+        }
+
+        const validation = getValidatedServerBase();
+        console.log('[DEBUG] Server validation:', validation);
+        if (!validation.ok || !validation.url) {
+          console.error('[DEBUG] Invalid server URL:', validation);
+          applyServerStatus('invalid', { force: true });
+          stopPolling();
+          return;
+        }
 
       clearReconnectTimer();
       setStreamState(STREAM_STATES.CONNECTING);
@@ -7198,7 +7202,7 @@
         markErrorHandled(err);
       }
     } catch (err) {
-      console.error('Unexpected stream connection failure', err);
+      console.error('[DEBUG] Stream connection failed:', err);
       applyServerStatus('error', { force: true });
       if (!isErrorHandled(err)) {
         toast(resolveErrorMessage(err, 'Failed to connect to stream'));


### PR DESCRIPTION
## Summary
- add debug logging around stream connection attempts
- log validation results and invalid server conditions during connection setup
- standardize error logging when connection attempts fail

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99994159883219c636a87803f6d8a