### PR TITLE
Add pyproject configuration for setuptools packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "m0-ticker"
+version = "0.1.0"
+description = "Broadcast-ready ticker widgets and highlight tooling."
+readme = "README.md"
+authors = [{ name = "M0 Ticker Maintainers" }]
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["highlights*", "highlighter*"]
+exclude = [
+    "tests",
+    "tests.*",
+    "public",
+    "public.*",
+    "node_modules",
+    "node_modules.*",
+    "archive",
+    "archive.*"
+]


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` so setuptools can build the project in editable mode
- configure explicit package discovery to include the `highlights` and `highlighter` packages while excluding non-Python assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7991330d88321b0c463ff61c9a413